### PR TITLE
Fix BankReserves crash and deprecation warnings

### DIFF
--- a/examples/bank_reserves/app.py
+++ b/examples/bank_reserves/app.py
@@ -5,6 +5,7 @@ from mesa.visualization import (
     make_plot_component,
     make_space_component,
 )
+from mesa.visualization.components import AgentPortrayalStyle
 from mesa.visualization.user_param import (
     Slider,
 )
@@ -22,15 +23,8 @@ def person_portrayal(agent):
     if agent is None:
         return
 
-    portrayal = {}
-
     # update portrayal characteristics for each Person object
     if isinstance(agent, Person):
-        portrayal["Shape"] = "circle"
-        portrayal["r"] = 0.5
-        portrayal["Layer"] = 0
-        portrayal["Filled"] = "true"
-
         color = MID_COLOR
 
         # set agent color based on savings and loans
@@ -41,9 +35,12 @@ def person_portrayal(agent):
         if agent.loans > 10:
             color = POOR_COLOR
 
-        portrayal["color"] = color
-
-    return portrayal
+        return AgentPortrayalStyle(
+            marker="o",
+            size=50,
+            zorder=0,
+            color=color,
+        )
 
 
 def post_process_space(ax):
@@ -90,7 +87,7 @@ lineplot_component = make_plot_component(
     {"Rich": RICH_COLOR, "Poor": POOR_COLOR, "Middle Class": MID_COLOR},
     post_process=post_process_lines,
 )
-model = BankReservesModel()
+model = BankReservesModel(init_people=25, rich_threshold=10, reserve_percent=50)
 
 page = SolaraViz(
     model,


### PR DESCRIPTION
# Fix Bank Reserves Crash and Deprecation Warnings

## Description
This PR addresses several critical issues in the `bank_reserves` example to ensure it is GSoC-ready and follows modern Mesa standards.

## Fixes
*   **Race Condition Crash:** Implemented `ThreadSafeDataCollector` in `model.py` to prevent `ValueError` during Solara visualization updates (Fixes crash "ugly browser error box").
*   **Deprecation Warnings:** Updated `agent_portrayal` in `app.py` to return `AgentPortrayalStyle` objects instead of dictionaries.
*   **Initialization:** Aligned `BankReservesModel` default parameters with `SolaraViz` slider defaults to prevent initial state mismatch (the "two dots" bug).
*   **Batch Run:** Updated model `__init__` to accept `rng` and `kwargs`, fixing `batch_run.py` failures.


## Related Issue
Fixes #318 