### PR TITLE
Add needs-based Wolf-Sheep behavioral model

### DIFF
--- a/examples/needs_wolf_sheep/README.md
+++ b/examples/needs_wolf_sheep/README.md
@@ -1,0 +1,84 @@
+# Needs-Based Wolf-Sheep Predation
+
+## Summary
+
+An extension of Mesa's core [Wolf-Sheep Predation](https://github.com/projectmesa/mesa/tree/main/mesa/examples/advanced/wolf_sheep) model that replaces hardcoded behavioral rules with a **needs-based behavioral architecture**. Animals have continuous internal states — hunger, fear, and fatigue — that evolve each simulation step. Behavior is driven by whichever need is most pressing at any moment, creating more realistic and emergent dynamics.
+
+This model was built as part of evaluating how well Mesa supports established behavioral theories, following the approach described in Mesa's [Behavioral Framework project](https://github.com/mesa/mesa/wiki/GSoC-2026-Project-Ideas#behavioral-framework) and the discussions on [Continuous States (#2529)](https://github.com/projectmesa/mesa/discussions/2529), [Tasks (#2526)](https://github.com/projectmesa/mesa/discussions/2526), and [Behavioral Framework (#2538)](https://github.com/projectmesa/mesa/discussions/2538).
+
+## How It Works
+
+### Internal States (Needs)
+
+Each animal tracks three continuous internal states (floats from 0.0 to 1.0):
+
+| Need | What drives it | How it's satisfied |
+|------|---------------|--------------------|
+| **Hunger** | Increases as energy drops below maximum | Eating (sheep eat grass, wolves eat sheep) |
+| **Fear** | Spikes when predators are nearby | Moving away from threats |
+| **Fatigue** | Increases with movement | Resting in place |
+
+### Decision Mechanism
+
+Each step, the agent selects the action corresponding to its highest need:
+- **Fear > all** → Flee (move away from threats)
+- **Hunger > all** → Eat (seek and consume food)
+- **Fatigue > all** → Rest (stay in place, recover)
+- **All needs low** → Explore (move randomly)
+
+A small base "exploration drive" (0.15) ensures agents move even when all needs are satisfied.
+
+### Key Differences from Core Wolf-Sheep
+
+| Aspect | Core Wolf-Sheep | Needs-Based |
+|--------|----------------|-------------|
+| Decision logic | Fixed: move → eat → reproduce | Dynamic: highest need wins |
+| Movement cost | Always 1 energy | Varies: flee costs 1.5, rest costs 0.3 |
+| Fear response | Sheep avoid wolf cells (fixed) | Fear is a continuous state that competes with hunger/fatigue |
+| Wolf behavior | Always hunt if sheep nearby | Hungry wolves hunt; tired wolves rest; desperate wolves panic |
+| Emergent patterns | Predator-prey cycles | Predator-prey cycles + fatigue-driven rest patterns + fear waves |
+
+## How to Run
+
+Install Mesa with recommended dependencies:
+
+```
+pip install "mesa[rec]"
+```
+
+Then run:
+
+```
+solara run app.py
+```
+
+In the browser visualization:
+- **Red squares** = Wolves (darker red = hungrier)
+- **Blue circles** = Sheep (darker blue = more afraid)
+- **Green/brown squares** = Grass (green = fully grown)
+
+## Documented Friction Points
+
+Building this model surfaced several friction points relevant to Mesa's behavioral framework discussion:
+
+1. **No continuous state abstraction** — Internal needs are plain floats updated manually each step. There's no way to declare "hunger increases at rate 0.05/tick" or trigger events at threshold crossings (e.g., "when hunger > 0.8, interrupt current activity"). Discussion #2529 proposes exactly this.
+
+2. **No spatial query helpers** — "Count wolves within radius 2" requires iterating over neighborhood cells and filtering by type. A common operation in behavioral models that could benefit from a utility like `cell.neighborhood.count_type(Wolf, radius=2)`.
+
+3. **Sequential activation bias** — `shuffle_do` activates sheep before wolves (or vice versa), giving one species a slight first-mover advantage. For needs-based models where timing matters (a sheep that flees *before* a wolf hunts vs *after*), this ordering affects dynamics. Simultaneous activation would be more natural.
+
+4. **DataCollector with dynamic populations** — Collecting "average hunger of living wolves" requires a custom lambda that handles the empty-set case. Common enough in behavioral models to warrant a built-in helper.
+
+## Files
+
+- `agents.py` — NeedsBasedAnimal base class, NeedsSheep, NeedsWolf, NeedsGrass
+- `model.py` — NeedsWolfSheep model with data collection
+- `app.py` — Solara-based interactive visualization
+
+## Further Reading
+
+- Mesa core Wolf-Sheep: [mesa/examples/advanced/wolf_sheep](https://github.com/projectmesa/mesa/tree/main/mesa/examples/advanced/wolf_sheep)
+- Continuous States discussion: [#2529](https://github.com/projectmesa/mesa/discussions/2529)
+- Tasks discussion: [#2526](https://github.com/projectmesa/mesa/discussions/2526)
+- Behavioral Framework discussion: [#2538](https://github.com/projectmesa/mesa/discussions/2538)
+- Wilensky, U. (1997). NetLogo Wolf Sheep Predation model.

--- a/examples/needs_wolf_sheep/agents.py
+++ b/examples/needs_wolf_sheep/agents.py
@@ -1,0 +1,307 @@
+"""
+Needs-Based Wolf-Sheep Agents
+==============================
+
+Extends Mesa's core Wolf-Sheep model with continuous internal states
+(hunger, fear, fatigue) that drive behavior through priority-based
+decision-making. Built as a behavioral framework evaluation for GSoC 2026.
+
+Key differences from core Wolf-Sheep:
+- Agents have continuous internal needs that evolve each step
+- Behavior is driven by which need is most pressing, not hardcoded rules
+- Wolves balance hunting vs fleeing vs resting based on internal state
+- Sheep balance grazing vs fleeing vs resting based on internal state
+
+Friction points documented inline with # FRICTION comments.
+"""
+
+from mesa.discrete_space import CellAgent, FixedAgent
+
+
+class NeedsBasedAnimal(CellAgent):
+    """Base animal with continuous internal states driving behavior.
+
+    Internal states (all floats 0.0–1.0):
+        hunger: Increases each step. Reduced by eating.
+        fear: Spikes when predators are nearby. Decays when safe.
+        fatigue: Increases with movement, decreases with rest.
+    """
+
+    def __init__(
+        self,
+        model,
+        energy=8,
+        p_reproduce=0.04,
+        energy_from_food=4,
+        cell=None,
+    ):
+        super().__init__(model)
+        self.energy = energy
+        self.p_reproduce = p_reproduce
+        self.energy_from_food = energy_from_food
+        self.cell = cell
+
+        # Continuous internal states (needs)
+        self.hunger = 0.0
+        self.fear = 0.0
+        self.fatigue = 0.0
+
+        # Tracking for analysis
+        self.last_action = "idle"
+
+    def _update_needs(self):
+        """Evolve internal states based on current situation.
+
+        # FRICTION: Mesa has no built-in "continuous state" abstraction.
+        # We manually update floats each step. There's no way to say
+        # "hunger increases at rate 0.05/tick" declaratively, nor to
+        # trigger an event when hunger crosses a threshold (e.g., 0.8).
+        # Discussion #2529 proposes exactly this — ContinuousState with
+        # rate-of-change and threshold events.
+        """
+        # Hunger increases each step, proportional to missing energy
+        max_energy = 20.0
+        self.hunger = min(1.0, max(0.0, 1.0 - (self.energy / max_energy)))
+
+        # Fatigue increases slightly each step, more if moved last step
+        if self.last_action in ("flee", "hunt", "graze", "explore"):
+            self.fatigue = min(1.0, self.fatigue + 0.08)
+        else:
+            self.fatigue = max(0.0, self.fatigue - 0.15)
+
+        # Fear: computed from nearby threats (subclass-specific)
+        self.fear = self._compute_fear()
+
+    def _compute_fear(self):
+        """Compute fear level from nearby threats. Override in subclass."""
+        return 0.0
+
+    def _decide(self):
+        """Select action based on which need is most pressing.
+
+        This is the core needs-based decision mechanism: the highest
+        need wins. Ties broken by priority order: fear > hunger > fatigue.
+        """
+        needs = {
+            "flee": self.fear,
+            "eat": self.hunger,
+            "rest": self.fatigue,
+            "explore": 0.15,  # Base exploration drive
+        }
+        return max(needs, key=needs.get)
+
+    def _act_flee(self):
+        """Move away from threats."""
+        self.last_action = "flee"
+        self.energy -= 1.5  # Fleeing costs more energy
+        self.cell = self.cell.neighborhood.select_random_cell()
+
+    def _act_rest(self):
+        """Stay in place, recover fatigue."""
+        self.last_action = "rest"
+        self.fatigue = max(0.0, self.fatigue - 0.3)
+        self.energy -= 0.3  # Resting costs minimal energy
+
+    def _act_explore(self):
+        """Move randomly."""
+        self.last_action = "explore"
+        self.energy -= 1
+        self.cell = self.cell.neighborhood.select_random_cell()
+
+    def _act_eat(self):
+        """Try to eat. Subclass implements specifics."""
+        raise NotImplementedError
+
+    def spawn_offspring(self):
+        """Create offspring with inherited energy."""
+        self.energy /= 2
+        self.__class__(
+            self.model,
+            self.energy,
+            self.p_reproduce,
+            self.energy_from_food,
+            self.cell,
+        )
+
+    def step(self):
+        """Execute one step: update needs, decide, act, check survival."""
+        self._update_needs()
+
+        # Needs-based decision
+        action = self._decide()
+
+        if action == "flee":
+            self._act_flee()
+        elif action == "eat":
+            self._act_eat()
+        elif action == "rest":
+            self._act_rest()
+        else:
+            self._act_explore()
+
+        # Death check
+        if self.energy < 0:
+            self.remove()
+            return
+
+        # Reproduction (same as core Wolf-Sheep)
+        if self.random.random() < self.p_reproduce:
+            self.spawn_offspring()
+
+
+class NeedsSheep(NeedsBasedAnimal):
+    """A sheep with needs-based behavior.
+
+    Behavior priorities:
+    - High fear → flee from wolves
+    - High hunger → seek and eat grass
+    - High fatigue → rest in place
+    - Otherwise → explore randomly
+    """
+
+    def _compute_fear(self):
+        """Fear based on nearby wolves."""
+        # FRICTION: self.cell.neighborhood returns a CellCollection.
+        # To count wolves, we iterate over all neighboring cells and
+        # their agents. There's no built-in "count agents of type X
+        # within radius R" — you compose it from neighborhood + select.
+        # This works but is verbose for a very common operation.
+        wolf_count = 0
+        for cell in self.cell.neighborhood:
+            for agent in cell.agents:
+                if isinstance(agent, NeedsWolf):
+                    wolf_count += 1
+
+        # Fear scales with wolf proximity — 1 wolf = 0.4, 2+ = near max
+        return min(1.0, wolf_count * 0.4)
+
+    def _act_eat(self):
+        """Try to eat grass at current location, or move toward grass."""
+        self.last_action = "graze"
+        grass = next(
+            (obj for obj in self.cell.agents if isinstance(obj, NeedsGrass)),
+            None,
+        )
+        if grass is not None and grass.fully_grown:
+            self.energy += self.energy_from_food
+            grass.get_eaten()
+            self.hunger = max(0.0, self.hunger - 0.3)
+        else:
+            # No grass here — move toward grass
+            cells_with_grass = []
+            for cell in self.cell.neighborhood:
+                for agent in cell.agents:
+                    if isinstance(agent, NeedsGrass) and agent.fully_grown:
+                        cells_with_grass.append(cell)
+                        break
+
+            if cells_with_grass:
+                self.cell = self.random.choice(cells_with_grass)
+            else:
+                self.cell = self.cell.neighborhood.select_random_cell()
+            self.energy -= 1
+
+    def _act_flee(self):
+        """Move away from wolves — prefer cells without wolves."""
+        self.last_action = "flee"
+        self.energy -= 1.5
+
+        safe_cells = []
+        for cell in self.cell.neighborhood:
+            has_wolf = any(isinstance(a, NeedsWolf) for a in cell.agents)
+            if not has_wolf:
+                safe_cells.append(cell)
+
+        if safe_cells:
+            self.cell = self.random.choice(safe_cells)
+        else:
+            # Surrounded — move randomly
+            self.cell = self.cell.neighborhood.select_random_cell()
+
+
+class NeedsWolf(NeedsBasedAnimal):
+    """A wolf with needs-based behavior.
+
+    Behavior priorities:
+    - High hunger → hunt for sheep
+    - High fatigue → rest to recover
+    - Otherwise → explore territory
+
+    Wolves have low base fear (apex predator), but fear increases
+    slightly when energy is critically low (desperation).
+    """
+
+    def _compute_fear(self):
+        """Wolves fear starvation, not other agents."""
+        if self.energy < 3:
+            return 0.3  # Desperate — triggers erratic behavior
+        return 0.0
+
+    def _act_eat(self):
+        """Hunt: move toward sheep and try to eat one."""
+        self.last_action = "hunt"
+
+        # Check current cell for sheep
+        sheep_here = [obj for obj in self.cell.agents if isinstance(obj, NeedsSheep)]
+        if sheep_here:
+            target = self.random.choice(sheep_here)
+            self.energy += self.energy_from_food
+            target.remove()
+            self.hunger = max(0.0, self.hunger - 0.5)
+            return
+
+        # No sheep here — move toward sheep
+        # FRICTION: There's no built-in "find nearest agent of type X"
+        # utility. We scan neighborhood manually. For larger search
+        # radii this would need nested loops or a spatial query API.
+        cells_with_sheep = []
+        for cell in self.cell.neighborhood:
+            if any(isinstance(a, NeedsSheep) for a in cell.agents):
+                cells_with_sheep.append(cell)
+
+        if cells_with_sheep:
+            self.cell = self.random.choice(cells_with_sheep)
+        else:
+            self.cell = self.cell.neighborhood.select_random_cell()
+        self.energy -= 1
+
+    def _act_flee(self):
+        """When desperate (low energy), move erratically."""
+        self.last_action = "flee"
+        self.energy -= 1
+        self.cell = self.cell.neighborhood.select_random_cell()
+
+
+class NeedsGrass(FixedAgent):
+    """Grass patch — identical to core Wolf-Sheep."""
+
+    def __init__(self, model, countdown, grass_regrowth_time, cell):
+        super().__init__(model)
+        self._fully_grown = countdown == 0
+        self.grass_regrowth_time = grass_regrowth_time
+        self.cell = cell
+
+        if not self._fully_grown:
+            self.model.simulator.schedule_event_relative(
+                setattr, countdown, function_args=[self, "fully_grown", True]
+            )
+
+    @property
+    def fully_grown(self):
+        """Whether the grass patch is fully grown."""
+        return self._fully_grown
+
+    @fully_grown.setter
+    def fully_grown(self, value: bool) -> None:
+        """Set grass growth state and schedule regrowth if eaten."""
+        self._fully_grown = value
+
+        if not value:
+            self.model.simulator.schedule_event_relative(
+                setattr,
+                self.grass_regrowth_time,
+                function_args=[self, "fully_grown", True],
+            )
+
+    def get_eaten(self):
+        self.fully_grown = False

--- a/examples/needs_wolf_sheep/agents.py
+++ b/examples/needs_wolf_sheep/agents.py
@@ -21,7 +21,7 @@ from mesa.discrete_space import CellAgent, FixedAgent
 class NeedsBasedAnimal(CellAgent):
     """Base animal with continuous internal states driving behavior.
 
-    Internal states (all floats 0.0–1.0):
+    Internal states (all floats 0.0-1.0):
         hunger: Increases each step. Reduced by eating.
         fear: Spikes when predators are nearby. Decays when safe.
         fatigue: Increases with movement, decreases with rest.

--- a/examples/needs_wolf_sheep/app.py
+++ b/examples/needs_wolf_sheep/app.py
@@ -4,10 +4,9 @@ Solara visualization for the Needs-Based Wolf-Sheep model.
 Run with: solara run app.py
 """
 
+from agents import NeedsGrass, NeedsSheep, NeedsWolf
 from mesa.experimental.devs import ABMSimulator
 from mesa.visualization import SolaraViz, make_plot_component, make_space_component
-
-from agents import NeedsGrass, NeedsSheep, NeedsWolf
 from model import NeedsWolfSheep
 
 

--- a/examples/needs_wolf_sheep/app.py
+++ b/examples/needs_wolf_sheep/app.py
@@ -1,0 +1,122 @@
+"""
+Solara visualization for the Needs-Based Wolf-Sheep model.
+
+Run with: solara run app.py
+"""
+
+from mesa.experimental.devs import ABMSimulator
+from mesa.visualization import SolaraViz, make_plot_component, make_space_component
+
+from agents import NeedsGrass, NeedsSheep, NeedsWolf
+from model import NeedsWolfSheep
+
+
+def agent_portrayal(agent):
+    """Define how agents are drawn on the grid."""
+    if isinstance(agent, NeedsWolf):
+        # Wolf color darkens with hunger (more red = more hungry)
+        hunger_intensity = int(200 + 55 * agent.hunger)
+        return {
+            "color": f"#{hunger_intensity:02x}3232",
+            "marker": "s",  # Square
+            "size": 40,
+        }
+    elif isinstance(agent, NeedsSheep):
+        # Sheep color changes with fear (more blue = more afraid)
+        fear_intensity = int(100 + 155 * agent.fear)
+        return {
+            "color": f"#6464{fear_intensity:02x}",
+            "marker": "o",  # Circle
+            "size": 30,
+        }
+    elif isinstance(agent, NeedsGrass):
+        if agent.fully_grown:
+            return {"color": "#00aa00", "marker": "s", "size": 75}
+        else:
+            return {"color": "#c8b478", "marker": "s", "size": 75}
+    return {}
+
+
+model_params = {
+    "width": {
+        "type": "SliderInt",
+        "value": 20,
+        "label": "Grid Width",
+        "min": 10,
+        "max": 40,
+        "step": 1,
+    },
+    "height": {
+        "type": "SliderInt",
+        "value": 20,
+        "label": "Grid Height",
+        "min": 10,
+        "max": 40,
+        "step": 1,
+    },
+    "initial_sheep": {
+        "type": "SliderInt",
+        "value": 100,
+        "label": "Initial Sheep",
+        "min": 10,
+        "max": 300,
+        "step": 10,
+    },
+    "initial_wolves": {
+        "type": "SliderInt",
+        "value": 25,
+        "label": "Initial Wolves",
+        "min": 5,
+        "max": 100,
+        "step": 5,
+    },
+    "sheep_reproduce": {
+        "type": "SliderFloat",
+        "value": 0.04,
+        "label": "Sheep Reproduction Rate",
+        "min": 0.01,
+        "max": 0.1,
+        "step": 0.01,
+    },
+    "wolf_reproduce": {
+        "type": "SliderFloat",
+        "value": 0.05,
+        "label": "Wolf Reproduction Rate",
+        "min": 0.01,
+        "max": 0.1,
+        "step": 0.01,
+    },
+    "grass_regrowth_time": {
+        "type": "SliderInt",
+        "value": 30,
+        "label": "Grass Regrowth Time",
+        "min": 5,
+        "max": 60,
+        "step": 5,
+    },
+}
+
+# Population dynamics plot
+PopulationPlot = make_plot_component(
+    {"Wolves": "red", "Sheep": "blue", "Grass": "green"}
+)
+
+# Needs metrics plot
+NeedsPlot = make_plot_component(
+    {"Avg Wolf Hunger": "darkred", "Avg Sheep Fear": "darkblue"}
+)
+
+simulator = ABMSimulator()
+model = NeedsWolfSheep(simulator=simulator)
+
+page = SolaraViz(
+    model,
+    components=[
+        make_space_component(agent_portrayal),
+        PopulationPlot,
+        NeedsPlot,
+    ],
+    model_params=model_params,
+    name="Needs-Based Wolf-Sheep Predation",
+    simulator=simulator,
+)

--- a/examples/needs_wolf_sheep/model.py
+++ b/examples/needs_wolf_sheep/model.py
@@ -1,0 +1,161 @@
+"""
+Needs-Based Wolf-Sheep Predation Model
+========================================
+
+Extends Mesa's core Wolf-Sheep model with needs-based behavioral architecture.
+Animals have continuous internal states (hunger, fear, fatigue) that evolve
+each step and drive behavior through priority-based decision-making.
+
+Built as a behavioral framework evaluation for GSoC 2026, exploring how well
+Mesa supports established behavioral theories. This model evaluates the
+needs-based approach specifically, documenting friction points and comparing
+emergent dynamics against the core rule-based Wolf-Sheep.
+
+References:
+- Mesa core Wolf-Sheep: mesa.examples.advanced.wolf_sheep
+- Discussion #2529: Continuous States
+- Discussion #2526: Tasks with duration
+- Discussion #2538: Behavioral Framework
+- Wilensky, U. (1997). NetLogo Wolf Sheep Predation model.
+"""
+
+import math
+
+from mesa import Model
+from mesa.datacollection import DataCollector
+from mesa.discrete_space import OrthogonalVonNeumannGrid
+from mesa.experimental.devs import ABMSimulator
+
+from agents import NeedsGrass, NeedsSheep, NeedsWolf
+
+
+class NeedsWolfSheep(Model):
+    """Wolf-Sheep model with needs-based behavioral architecture.
+
+    Key differences from core Wolf-Sheep:
+    - Animals have continuous internal states: hunger, fear, fatigue
+    - Behavior is driven by which need is most pressing
+    - More data collected: average needs levels, action distributions
+    """
+
+    description = (
+        "Wolf-Sheep Predation with needs-based behavioral architecture. "
+        "Animals balance hunger, fear, and fatigue to select actions."
+    )
+
+    def __init__(
+        self,
+        width=20,
+        height=20,
+        initial_sheep=100,
+        initial_wolves=25,
+        sheep_reproduce=0.04,
+        wolf_reproduce=0.05,
+        wolf_gain_from_food=20.0,
+        sheep_gain_from_food=4.0,
+        grass_regrowth_time=30,
+        seed=None,
+        simulator: ABMSimulator = None,
+    ):
+        super().__init__(seed=seed)
+        self.simulator = simulator
+        self.simulator.setup(self)
+
+        self.width = width
+        self.height = height
+
+        # Create grid
+        self.grid = OrthogonalVonNeumannGrid(
+            [self.height, self.width],
+            torus=True,
+            capacity=math.inf,
+            random=self.random,
+        )
+
+        # Data collection — includes needs-based metrics
+        # FRICTION: DataCollector works well for model-level aggregates,
+        # but collecting per-agent needs over time requires agent_reporters
+        # which creates large dataframes. There's no built-in way to
+        # efficiently track "average hunger of living wolves" without
+        # a custom lambda that handles the empty-agentset case.
+        self.datacollector = DataCollector(
+            model_reporters={
+                "Wolves": lambda m: len(m.agents_by_type[NeedsWolf]),
+                "Sheep": lambda m: len(m.agents_by_type[NeedsSheep]),
+                "Grass": lambda m: len(
+                    m.agents_by_type[NeedsGrass].select(lambda a: a.fully_grown)
+                ),
+                "Avg Wolf Hunger": lambda m: (
+                    m.agents_by_type[NeedsWolf].agg(
+                        "hunger", func=lambda x: sum(x) / len(x)
+                    )
+                    if len(m.agents_by_type[NeedsWolf]) > 0
+                    else 0
+                ),
+                "Avg Sheep Fear": lambda m: (
+                    m.agents_by_type[NeedsSheep].agg(
+                        "fear", func=lambda x: sum(x) / len(x)
+                    )
+                    if len(m.agents_by_type[NeedsSheep]) > 0
+                    else 0
+                ),
+            },
+            agent_reporters={
+                "energy": "energy",
+                "hunger": "hunger",
+                "fear": "fear",
+                "fatigue": "fatigue",
+                "last_action": "last_action",
+            },
+        )
+
+        # Create sheep
+        NeedsSheep.create_agents(
+            self,
+            initial_sheep,
+            energy=self.rng.random((initial_sheep,)) * 2 * sheep_gain_from_food,
+            p_reproduce=sheep_reproduce,
+            energy_from_food=sheep_gain_from_food,
+            cell=self.random.choices(self.grid.all_cells.cells, k=initial_sheep),
+        )
+
+        # Create wolves
+        NeedsWolf.create_agents(
+            self,
+            initial_wolves,
+            energy=self.rng.random((initial_wolves,)) * 2 * wolf_gain_from_food,
+            p_reproduce=wolf_reproduce,
+            energy_from_food=wolf_gain_from_food,
+            cell=self.random.choices(self.grid.all_cells.cells, k=initial_wolves),
+        )
+
+        # Create grass patches
+        for cell in self.grid:
+            fully_grown = self.random.choice([True, False])
+            countdown = (
+                0 if fully_grown else self.random.randrange(0, grass_regrowth_time)
+            )
+            NeedsGrass(self, countdown, grass_regrowth_time, cell)
+
+        self.running = True
+        self.datacollector.collect(self)
+
+    def step(self):
+        """Execute one step: sheep act, then wolves act."""
+        # FRICTION: Activation order matters for predator-prey dynamics.
+        # Mesa's shuffle_do is clean for this, but there's no built-in
+        # way to say "activate sheep and wolves simultaneously" (which
+        # would be needed for a PettingZoo Parallel wrapper). The
+        # sequential activation (sheep first, then wolves) creates a
+        # slight advantage for sheep — they can flee before wolves hunt.
+        self.agents_by_type[NeedsSheep].shuffle_do("step")
+        self.agents_by_type[NeedsWolf].shuffle_do("step")
+
+        self.datacollector.collect(self)
+
+        # Stop if one species is extinct
+        if (
+            len(self.agents_by_type[NeedsWolf]) == 0
+            or len(self.agents_by_type[NeedsSheep]) == 0
+        ):
+            self.running = False

--- a/examples/needs_wolf_sheep/model.py
+++ b/examples/needs_wolf_sheep/model.py
@@ -21,12 +21,11 @@ References:
 
 import math
 
+from agents import NeedsGrass, NeedsSheep, NeedsWolf
 from mesa import Model
 from mesa.datacollection import DataCollector
 from mesa.discrete_space import OrthogonalVonNeumannGrid
 from mesa.experimental.devs import ABMSimulator
-
-from agents import NeedsGrass, NeedsSheep, NeedsWolf
 
 
 class NeedsWolfSheep(Model):


### PR DESCRIPTION
## Summary
- Adds a needs-based extension of the core Wolf-Sheep predation model under `examples/needs_wolf_sheep/`
- Animals have continuous internal states (hunger, fear, fatigue) that evolve each step and drive behavior through priority-based decision-making
- Documents friction points relevant to Mesa behavioral framework discussions (#2529, #2526, #2538)

## What's different from core Wolf-Sheep
- Agents select actions based on **which need is most pressing** rather than hardcoded rules
- Wolves balance hunting vs resting vs exploring based on internal state
- Sheep balance grazing vs fleeing vs resting based on nearby threats
- DataCollector tracks average needs levels alongside population dynamics

## Files
| File | Description |
|------|-------------|
| `agents.py` | `NeedsBasedAnimal(CellAgent)` base + `NeedsSheep`, `NeedsWolf`, `NeedsGrass(FixedAgent)` |
| `model.py` | `NeedsWolfSheep(Model)` with ABMSimulator integration |
| `app.py` | Solara visualization with need-driven color intensity |
| `README.md` | Model description, friction points, and emergent behaviors |

## Friction points documented
1. **No continuous state abstraction** — needs are plain floats updated manually (#2529)
2. **No spatial query helpers** — counting wolves in neighborhood requires manual iteration
3. **Sequential activation bias** — `shuffle_do` activates one species then the other (#2526)
4. **DataCollector with dynamic populations** — custom lambdas needed for empty-set handling

## Testing
- Headless: runs 100+ steps without crashes on Mesa 3.3.1
- Visualization: `solara run app.py` renders correctly
- Linting: passes `flake8` and `black`