### PR TITLE
fix(emperor-dilemma): replace relative imports and fix unseeded random calls

### DIFF
--- a/examples/emperor_dilemma/app.py
+++ b/examples/emperor_dilemma/app.py
@@ -1,3 +1,4 @@
+from emperor_dilemma.model import EmperorModel
 from mesa.visualization import (
     CommandConsole,
     Slider,
@@ -6,8 +7,6 @@ from mesa.visualization import (
     make_plot_component,
 )
 from mesa.visualization.components.portrayal_components import AgentPortrayalStyle
-
-from .model import EmperorModel
 
 # Colors matching Figure 2
 COLOR_COMPLY_QUIET = "#F0F8FF"  # AliceBlue

--- a/examples/emperor_dilemma/model.py
+++ b/examples/emperor_dilemma/model.py
@@ -1,10 +1,7 @@
-import random
-
+from emperor_dilemma.agents import EmperorAgent
 from mesa import Model
 from mesa.datacollection import DataCollector
 from mesa.discrete_space.grid import OrthogonalMooreGrid
-
-from .agents import EmperorAgent
 
 
 class EmperorModel(Model):
@@ -81,7 +78,7 @@ class EmperorModel(Model):
                 by = (start_y + (i // int(num_believers**0.5 + 1))) % self.height
                 believer_coords.add((bx, by))
         else:
-            believer_coords = set(random.sample(all_coords, num_believers))
+            believer_coords = set(self.random.sample(all_coords, num_believers))
 
         for x, y in all_coords:
             if (x, y) in believer_coords:
@@ -89,7 +86,7 @@ class EmperorModel(Model):
                 conviction = 1.0
             else:
                 p_belief = -1
-                conviction = random.uniform(0.01, 0.38)
+                conviction = self.random.uniform(0.01, 0.38)
 
             agent = EmperorAgent(self, p_belief, conviction, self.k)
 


### PR DESCRIPTION
## Summary

Fixes two bugs preventing the Emperor's Dilemma example from running, as reported in #337.

### Bug 1 — Relative imports break Solara module resolution
`app.py` used `from .model import EmperorModel` and `model.py` used `from .agents import EmperorAgent`. Solara loads example modules in a flat namespace and cannot resolve relative imports. Fixed by switching to absolute imports (`from emperor_dilemma.model import ...`), consistent with how other examples in this repo are structured (e.g. `bank_reserves`).

### Bug 2 — Module-level `random` bypasses the seeded RNG
`model.py` imported the stdlib `random` module and called `random.sample()` and `random.uniform()` during agent initialisation. This means the `rng` parameter passed to `EmperorModel()` — and exposed as a slider in the UI — had no effect on the initial believer placement or conviction values, making runs non-reproducible. Fixed by replacing both calls with `self.random.sample()` and `self.random.uniform()`.

## Test plan

- [ ] `solara run app.py` starts without `ImportError`
- [ ] Agents render on the grid with correct colors (comply/enforce states)
- [ ] Changing the Random Seed slider and clicking Reset produces a different initial configuration
- [ ] Line plot shows Compliance / Enforcement / False Enforcement over time

🤖 Generated with [Claude Code](https://claude.com/claude-code)