### PR TITLE
fix(hex_ant): fix relative imports and PropertyLayer API to make example fully runnable

### DIFF
--- a/examples/hex_ant/app.py
+++ b/examples/hex_ant/app.py
@@ -3,8 +3,8 @@ from matplotlib.colors import LinearSegmentedColormap, ListedColormap
 from mesa.visualization import SolaraViz, make_space_component
 from mesa.visualization.components import PropertyLayerStyle
 
-from .agent import AntState
-from .model import AntForaging
+from agent import AntState
+from model import AntForaging
 
 plt.rcParams["figure.figsize"] = (10, 10)
 

--- a/examples/hex_ant/app.py
+++ b/examples/hex_ant/app.py
@@ -3,8 +3,12 @@ from matplotlib.colors import LinearSegmentedColormap, ListedColormap
 from mesa.visualization import SolaraViz, make_space_component
 from mesa.visualization.components import PropertyLayerStyle
 
-from agent import AntState
-from model import AntForaging
+try:
+    from .agent import AntState
+    from .model import AntForaging
+except ImportError:
+    from agent import AntState
+    from model import AntForaging
 
 plt.rcParams["figure.figsize"] = (10, 10)
 

--- a/examples/hex_ant/model.py
+++ b/examples/hex_ant/model.py
@@ -1,7 +1,10 @@
 import mesa
 from mesa.discrete_space import HexGrid
 
-from agent import Ant
+try:
+    from .agent import Ant
+except ImportError:
+    from agent import Ant
 
 
 class AntForaging(mesa.Model):

--- a/examples/hex_ant/model.py
+++ b/examples/hex_ant/model.py
@@ -1,7 +1,7 @@
 import mesa
 from mesa.discrete_space import HexGrid
 
-from .agent import Ant
+from agent import Ant
 
 
 class AntForaging(mesa.Model):
@@ -57,9 +57,9 @@ class AntForaging(mesa.Model):
         # Create the Nest in the center
         center = (self.grid.width // 2, self.grid.height // 2)
         # Spike the 'home' pheromone at the nest so ants can find it initially
-        self.grid.pheromone_home[center] = 1.0
+        self.grid.pheromone_home.data[center] = 1.0
         # Mark the home location
-        self.grid.home[center] = 1
+        self.grid.home.data[center] = 1
 
         # Scatter some Food Sources
         # Create 3 big clusters of food
@@ -101,7 +101,7 @@ class AntForaging(mesa.Model):
         """
         Apply evaporation to a pheromone layer.
         """
-        np_layer = self.grid.property_layers[layer_name]
+        np_layer = getattr(self.grid, layer_name).data
         np_layer *= 1.0 - self.evaporation_rate
 
         # Clamp to 0 to prevent negative values

--- a/rl/wolf_sheep/agents.py
+++ b/rl/wolf_sheep/agents.py
@@ -51,7 +51,7 @@ class WolfRL(Wolf):
         self.energy -= 1
 
         # If there are sheep present, eat one
-        x, y = self.pos
+        _x, _y = self.pos
         this_cell = self.model.grid.get_cell_list_contents([self.pos])
         sheep = [obj for obj in this_cell if isinstance(obj, Sheep)]
         if len(sheep) > 0:


### PR DESCRIPTION
### Summary
Closes #357 — hex_ant was completely non-functional. Running `solara run app.py` 
crashed immediately and the model never reached the browser. This PR works through 
every crash in sequence until the example fully runs.

### Bug / Issue
**Bug 1** — Relative imports in app.py and model.py

app.py — before
from .agent import AntState
from .model import AntForaging
 removed the . before the module

why this change
Relative imports (`.module`) only work when Python treats the directory as a package with a known parent. When Solara executes `app.py` directly, `__package__` is `None`, so there is no parent to be relative to

**Result:** Model loads past the import stage.

**Bug 2** — Direct PropertyLayer item assignment in `_init_environment`
model.py — before
self.grid.pheromone_home[center] = 1.0
self.grid.home[center] = 1

model.py — after
self.grid.pheromone_home.data[center] = 1.0
self.grid.home.data[center] = 1

**Why**
In Mesa 3.x, `PropertyLayer` is a wrapper object, not a numpy array. Direct item assignment (`layer[x, y] = val`) is not supported. The underlying numpy array is accessed through the `.data` attribute, which does support index assignment.


**Result:** Model initialises, nest and food sources are placed, 
visualization opens in browser.

**Bug 3** — Wrong dynamic layer lookup in `_update_pheromone_layer`
model.py — before
np_layer = self.grid.property_layers[layer_name]

model.py — after
np_layer = getattr(self.grid, layer_name).data

**Why:** 

self.grid.property_layers does not exist as an attribute. `HexGrid` overrides `__getattr__` and routes ALL attribute access through the internal property layer dictionary — so accessing `.property_layers` is itself treated as a layer name lookup and fails. The correct pattern for dynamic layer access by name is `getattr(self.grid, layer_name)`. The `.data` is also needed here for the same reason as Bug 2 — numpy operations like `*=` and boolean masking must be performed on the raw 
array, not the wrapper object.

### Testing

<img width="1366" height="728" alt="{F6415441-5EB7-41B7-B4DC-BCB88C82849E}" src="https://github.com/user-attachments/assets/34dfb84c-49e6-4774-a1b8-898b0e4b0fd6" />

### Additional Notes
## Relation to existing PRs

- #377 and #380 — attempted import fixes only, both closed
- #427 — correctly fixes relative imports; the copy of the code worked on here already had clean absolute imports, so that was not the blocker. The PropertyLayer bugs are entirely separate and were not addressed by any existing PR.
- Bug 3 specifically would have crashed the model on step 1 even if every other fix had been applied first — it was the last hidden blocker.


## Verified
Tested on Windows, Mesa 3.5.0, Python 3.14:

- `solara run app.py` starts without error 
- Visualization opens at http://localhost:8765 
- Ants spawn at nest and begin foraging 
- Pheromone trails build up and evaporate each step 
- Returning ants (gold) follow home pheromone correctly 
- Food clusters deplete as ants pick up food 

**After Codex Suggestion**
In `model.py` and `app.py`: used try/except import pattern to support both `solara run app.py` (direct execution) and package import via test runner and it worked 

<img width="1366" height="727" alt="{335454A4-326F-42A9-8570-CFAF0F73B7DD}" src="https://github.com/user-attachments/assets/8a3d5a21-a035-4f7c-b110-abc53ba08771" />

**Also CI Failing Issue**
Also fixed a pre-existing lint error in rl/wolf_sheep/agents.py — two variables x, y were unpacked but never actually used anywhere. Renamed them to _x, _y to tell the linter they are intentionally unused. This was flagged by pre-commit CI and is unrelated to the hex_ant fix.