### PR TITLE
Remove dead Cell attribute initializations that shadow the mesa-geo band proxy

### DIFF
--- a/gis/population/population/space.py
+++ b/gis/population/population/space.py
@@ -18,7 +18,6 @@ class UgandaCell(Cell):
         **kwargs: dict,
     ):
         super().__init__(model, **kwargs)
-        self.population = None
 
     def step(self):
         pass

--- a/gis/rainfall/rainfall/space.py
+++ b/gis/rainfall/rainfall/space.py
@@ -18,9 +18,6 @@ class LakeCell(mg.Cell):
         **kwargs: dict,
     ):
         super().__init__(model, **kwargs)
-        self.elevation = None
-        self.water_level = None
-        self.water_level_normalized = None
 
     def step(self):
         pass

--- a/gis/urban_growth/urban_growth/space.py
+++ b/gis/urban_growth/urban_growth/space.py
@@ -31,12 +31,6 @@ class UrbanCell(mg.Cell):
         **kwargs: dict,
     ):
         super().__init__(model, **kwargs)
-        self.urban = None
-        self.slope = None
-        self.road_1 = None
-        self.excluded = None
-        self.land_use = None
-
         self.suitable = None
         self.road = None
         self.run_value = None


### PR DESCRIPTION
### Summary

Removes dead `self.<attr> = None` band initializations from the three GIS example `Cell` subclasses (`UrbanCell`, `LakeCell`, `UgandaCell`). Under [mesa-geo#332](https://github.com/mesa/mesa-geo/pull/332) these stale assignments shadow the new band proxy and crash all three models on instantiation.

### Bug / Issue

Related: [mesa-geo#332](https://github.com/mesa/mesa-geo/pull/332), part of [mesa-geo#328](https://github.com/mesa/mesa-geo/issues/328).

In [mesa-geo#332](https://github.com/mesa/mesa-geo/pull/332), `RasterLayer._data` becomes the single source of truth for band data and `Cell` proxies band access into those arrays via `__getattr__`/`__setattr__`.

The subclasses assign band attributes (`self.elevation = None` etc.) in `__init__`, before the band exists in `_data`. `__setattr__` falls through and plants a stale `None` in the instance `__dict__`, which Python resolves before `__getattr__`, so the proxy is never consulted. Reads return `None` permanently while writes land in the array, and the models raise `TypeError` once those values are used.

### Implementation

Removed the band initializations from each `__init__`. They were already redundant, since `apply_raster` populates these attributes anyway.

| File | Class | Removed |
|---|---|---|
| `gis/urban_growth/urban_growth/space.py` | `UrbanCell` | `urban`, `slope`, `road_1`, `excluded`, `land_use` |
| `gis/rainfall/rainfall/space.py` | `LakeCell` | `elevation`, `water_level`, `water_level_normalized` |
| `gis/population/population/space.py` | `UgandaCell` | `population` |

Only raster-band attributes were removed. Derived and instance-state attributes (`road`, `run_value`, `suitable`, `road_found`, `road_pixel`, `new_urbanized`, `old_urbanized`) never appear in `_data`, so they resolve normally and are left in place. `water_level_normalized` is included because it is re-applied via `apply_raster` every model step, making it a genuine band.

No other constructor logic was touched, and `requirements.txt` is unchanged.

### Testing

All three models run end to end against both `feat/cell-proxy-decoupling` and released `0.9.3`:

| Example | Before ([mesa-geo#332](https://github.com/mesa/mesa-geo/pull/332) branch) | After ([mesa-geo#332](https://github.com/mesa/mesa-geo/pull/332) branch) | After (0.9.3) |
|---|---|---|---|
| `gis/urban_growth` | `TypeError: '>' not supported between instances of 'NoneType' and 'NoneType'` | PASS | PASS |
| `gis/rainfall` | `TypeError: unsupported operand type(s) for +=: 'NoneType' and 'int'` | PASS | PASS |
| `gis/population` | `TypeError: must be real number, not NoneType` | PASS | PASS |

The failures are a regression from [mesa-geo#332](https://github.com/mesa/mesa-geo/pull/332), not pre-existing: all three run clean against pre-refactor `main`.

### Additional Notes

This prepares the examples for [mesa-geo#332](https://github.com/mesa/mesa-geo/pull/332) but does not depend on it. Verified against released `0.9.3`, so CI here is expected to pass and no `requirements.txt` bump is needed. Merge ordering is up to the maintainers.