### PR TITLE
Update warehouse example to the new meta-agents API

### DIFF
--- a/examples/warehouse/Readme.md
+++ b/examples/warehouse/Readme.md
@@ -10,13 +10,15 @@ This reality is the motivation for meta-agents. It allows users to represent the
 
 In this simulation, robots are given tasks to take retrieve inventory items and then take those items to the loading docks.
 
-Each `RobotAgent` is made up of sub-components that are treated as separate agents. For this simulation, each robot as a `SensorAgent`, `RouterAgent`, and `WorkerAgent`.
+Each `RobotAgent` is assembled with `MetaAgents.create` from sub-components treated as separate agents: a `SensorAgent`, `RouteAgent`, and `WorkerAgent`, with typed memberships (`router` / `sensor` / `worker`).
 
 This model demonstrates deliberate meta-agent creation. It shows the basics of meta-agent creation and different ways to use and reference sub-agent and meta-agent functions and attributes. (The alliance formation demonstrates emergent meta-agent creation.)
 
-In its current configuration, agents being part of multiple meta-agents is not supported
+The membership backend supports overlapping memberships (agents in multiple meta-agents); this example still creates one group per robot.
 
-An additional item of note is that to reference the RobotAgent created in model you will see `type(self.RobotAgent)` or `type(model.RobotAgent)` in various places. If you have any ideas for how to make this more user friendly please let us know or do a pull request.
+Robots are tracked via `model.robot_agent_type` (the dynamically created meta-agent class), not `type(model.RobotAgent)`.
+
+Default layout is a compact 8×8×2 warehouse. Size and seed are controlled through `WarehouseScenario` (`rows`, `cols`, `height`) and the model `rng`.
 
 ## Installation
 
@@ -37,6 +39,6 @@ To run the model interactively, in this directory, run the following command
 ## Files
 
 - `model.py`: Contains creation of agents, the network and management of agent execution.
-- `agents.py`: Contains logic for forming alliances and creation of new agents
+- `agents.py`: Contains inventory, routing, sensing, and worker agent logic for robots.
 - `app.py`: Contains the code for the interactive Solara visualization.
 - `make_warehouse`: Generates a warehouse numpy array with loading docks, inventory, and charging stations.

--- a/examples/warehouse/Readme.md
+++ b/examples/warehouse/Readme.md
@@ -16,16 +16,18 @@ This model demonstrates deliberate meta-agent creation. It shows the basics of m
 
 The membership backend supports overlapping memberships (agents in multiple meta-agents); this example still creates one group per robot.
 
-Robots are tracked via `model.robot_agent_type` (the dynamically created meta-agent class), not `type(model.RobotAgent)`.
+Robots are tracked via `model.robots` (explicit list) and are created with unique names `RobotAgent_0`, `RobotAgent_1` so string lookups are unambiguous. Each robot has typed memberships (`router`/`sensor`/`worker`) queried via `model.meta_agents.members_of(robot, relation=…)` and `groups_of(agent)`.
 
-Default layout is a compact 8×8×2 warehouse. Size and seed are controlled through `WarehouseScenario` (`rows`, `cols`, `height`) and the model `rng`.
+The membership backend (`model.membership_backend` / `model.meta_agents.backend`) tracks every `(agent, group, relation)` triplet. The app shows a shallow use: `len(model.membership_backend.as_triplets())` (6 triplets for 2 robots × 3 relations) and `model.meta_agents.query_memberships(robot)` in the “Memberships” panel.
+
+Layout is fully driven by `WarehouseScenario` (`rows`, `cols`, `height`, `rng`) and exposed as Solara sliders; `make_warehouse.get_warehouse_coords(rows, cols)` adapts dock/station placement to the scenario size.
 
 ## Installation
 
-This model requires Mesa's recommended install
+This model requires Mesa 4.0+ (meta-agents moved from `mesa.experimental` to `mesa.meta_agents`).
 
 ```
-    $ pip install 'mesa[rec]>=3'
+    $ pip install -U --pre "mesa[rec]>=4.0.0a0"
 ```
 
 ## How to Run

--- a/examples/warehouse/app.py
+++ b/examples/warehouse/app.py
@@ -4,18 +4,37 @@ import solara
 from mesa.visualization import SolaraViz
 from mesa.visualization.utils import update_counter
 from warehouse.agents import InventoryAgent
-from warehouse.make_warehouse import LOADING_DOCK_COORDS
-from warehouse.model import WarehouseModel
-
-# Constants
-LOADING_DOCKS = LOADING_DOCK_COORDS
-AXIS_LIMITS = {"x": (0, 8), "y": (0, 8), "z": (0, 3)}
+from warehouse.model import WarehouseModel, WarehouseScenario
 
 model_params = {
     "rng": {
         "type": "InputText",
         "value": 42,
-        "label": "Random number generator",
+        "label": "Random seed",
+    },
+    "rows": {
+        "type": "SliderInt",
+        "value": 8,
+        "label": "Rows:",
+        "min": 6,
+        "max": 20,
+        "step": 1,
+    },
+    "cols": {
+        "type": "SliderInt",
+        "value": 8,
+        "label": "Cols:",
+        "min": 6,
+        "max": 20,
+        "step": 1,
+    },
+    "height": {
+        "type": "SliderInt",
+        "value": 2,
+        "label": "Height:",
+        "min": 2,
+        "max": 5,
+        "step": 1,
     },
 }
 
@@ -42,6 +61,19 @@ def prepare_agent_data(model, agent_type, agent_label):
     ]
 
 
+def prepare_robot_data(model):
+    """Collect robot positions from the explicit robot list."""
+    return [
+        {
+            "x": agent.cell.coordinate[0],
+            "y": agent.cell.coordinate[1],
+            "z": agent.cell.coordinate[2],
+            "type": "Robot",
+        }
+        for agent in model.robots
+    ]
+
+
 @solara.component
 def plot_warehouse(model):
     """Visualize the warehouse model in a 3D scatter plot.
@@ -53,10 +85,7 @@ def plot_warehouse(model):
 
     # Prepare data for inventory and robot agents
     inventory_data = prepare_agent_data(model, InventoryAgent, "Inventory")
-    if model.robot_agent_type is None:
-        robot_data = []
-    else:
-        robot_data = prepare_agent_data(model, model.robot_agent_type, "Robot")
+    robot_data = prepare_robot_data(model)
 
     # Combine data into a single DataFrame
     data = pd.DataFrame(inventory_data + robot_data)
@@ -65,8 +94,8 @@ def plot_warehouse(model):
     fig = plt.figure(figsize=(8, 6))
     ax = fig.add_subplot(111, projection="3d")
 
-    # Highlight loading dock cells
-    for i, dock in enumerate(LOADING_DOCKS):
+    # Highlight loading dock cells (from scenario-driven coords)
+    for i, dock in enumerate(model.loading_docks):
         ax.scatter(
             dock[0],
             dock[1],
@@ -80,20 +109,25 @@ def plot_warehouse(model):
         )
 
     # Plot inventory agents
-    inventory = data[data["type"] == "Inventory"]
-    ax.scatter(
-        inventory["x"],
-        inventory["y"],
-        inventory["z"],
-        c="blue",
-        label="Inventory",
-        s=100,
-        marker="s",
-    )
+    if not data.empty:
+        inventory = data[data["type"] == "Inventory"]
+        if not inventory.empty:
+            ax.scatter(
+                inventory["x"],
+                inventory["y"],
+                inventory["z"],
+                c="blue",
+                label="Inventory",
+                s=100,
+                marker="s",
+            )
 
-    # Plot robot agents
-    robots = data[data["type"] == "Robot"]
-    ax.scatter(robots["x"], robots["y"], robots["z"], c="red", label="Robot", s=200)
+        # Plot robot agents
+        robots = data[data["type"] == "Robot"]
+        if not robots.empty:
+            ax.scatter(
+                robots["x"], robots["y"], robots["z"], c="red", label="Robot", s=200
+            )
 
     # Set labels, title, and legend
     ax.set_xlabel("X")
@@ -102,24 +136,59 @@ def plot_warehouse(model):
     ax.set_title("Warehouse Visualization")
     ax.legend()
 
-    # Configure plot appearance
+    # Configure plot appearance - from WarehouseScenario
     ax.grid(False)
-    ax.set_xlim(*AXIS_LIMITS["x"])
-    ax.set_ylim(*AXIS_LIMITS["y"])
-    ax.set_zlim(*AXIS_LIMITS["z"])
+    ax.set_xlim(0, model.scenario.rows)
+    ax.set_ylim(0, model.scenario.cols)
+    ax.set_zlim(0, model.scenario.height + 1)
     ax.axis("off")
 
     # Render the plot in Solara
     solara.FigureMatplotlib(fig)
 
 
+@solara.component
+def show_memberships(model):
+    """Shallow backend showcase: triplet count and per-robot relations."""
+    update_counter.get()
+    # Backend-authoritative count (MembershipBackend.as_triplets)
+    triplet_count = len(model.membership_backend.as_triplets())
+    solara.Text(f"Membership triplets (backend): {triplet_count}")
+
+    # Facade view for the first robot (if any)
+    robots = model.robots
+    if robots:
+        robot = robots[0]
+        view = model.meta_agents.query_memberships(robot)
+        # Show relations present on this robot
+        relations = sorted({edge.relation for edge in view.memberships})
+        solara.Text(
+            f"Robot {robot.unique_id} relations: {', '.join(map(str, relations))}"
+        )
+        # Also demonstrate members_of with relation filter
+        router = next(
+            iter(model.meta_agents.members_of(robot, relation="router")), None
+        )
+        sensor = next(
+            iter(model.meta_agents.members_of(robot, relation="sensor")), None
+        )
+        worker = next(
+            iter(model.meta_agents.members_of(robot, relation="worker")), None
+        )
+        solara.Text(
+            f"Members: router={getattr(router, 'unique_id', None)} "
+            f"sensor={getattr(sensor, 'unique_id', None)} "
+            f"worker={getattr(worker, 'unique_id', None)}"
+        )
+
+
 # Create initial model instance
-model = WarehouseModel()
+model = WarehouseModel(scenario=WarehouseScenario(rows=8, cols=8, height=2, rng=42))
 
 # Create the SolaraViz page
 page = SolaraViz(
     model,
-    components=[plot_warehouse],
+    components=[plot_warehouse, show_memberships],
     model_params=model_params,
     name="Pseudo-Warehouse Model",
 )

--- a/examples/warehouse/app.py
+++ b/examples/warehouse/app.py
@@ -4,11 +4,12 @@ import solara
 from mesa.visualization import SolaraViz
 from mesa.visualization.utils import update_counter
 from warehouse.agents import InventoryAgent
+from warehouse.make_warehouse import LOADING_DOCK_COORDS
 from warehouse.model import WarehouseModel
 
 # Constants
-LOADING_DOCKS = [(0, 0, 0), (0, 2, 0), (0, 4, 0), (0, 6, 0), (0, 8, 0)]
-AXIS_LIMITS = {"x": (0, 22), "y": (0, 20), "z": (0, 5)}
+LOADING_DOCKS = LOADING_DOCK_COORDS
+AXIS_LIMITS = {"x": (0, 8), "y": (0, 8), "z": (0, 3)}
 
 model_params = {
     "rng": {
@@ -52,7 +53,10 @@ def plot_warehouse(model):
 
     # Prepare data for inventory and robot agents
     inventory_data = prepare_agent_data(model, InventoryAgent, "Inventory")
-    robot_data = prepare_agent_data(model, type(model.RobotAgent), "Robot")
+    if model.robot_agent_type is None:
+        robot_data = []
+    else:
+        robot_data = prepare_agent_data(model, model.robot_agent_type, "Robot")
 
     # Combine data into a single DataFrame
     data = pd.DataFrame(inventory_data + robot_data)

--- a/examples/warehouse/requirements.txt
+++ b/examples/warehouse/requirements.txt
@@ -1,1 +1,1 @@
-mesa[rec]>=3
+mesa[rec]>=4.0.0a0

--- a/examples/warehouse/warehouse/__init__.py
+++ b/examples/warehouse/warehouse/__init__.py
@@ -1,0 +1,5 @@
+"""Warehouse meta-agent example."""
+
+from .model import WarehouseModel, WarehouseScenario
+
+__all__ = ["WarehouseModel", "WarehouseScenario"]

--- a/examples/warehouse/warehouse/agents.py
+++ b/examples/warehouse/warehouse/agents.py
@@ -151,7 +151,10 @@ class WorkerAgent(mesa.Agent):
             # fallback to robot's own move (wired via meta_methods)
             status = robot.move(robot.cell.coordinate, robot.path)  # type: ignore[attr-defined]
 
-        if status == "movement complete" and getattr(robot, "status", None) == "inventory":
+        if (
+            status == "movement complete"
+            and getattr(robot, "status", None) == "inventory"
+        ):
             source_coordinate = robot.cell.coordinate  # type: ignore[attr-defined]
             target_level = robot.item.cell.coordinate[2]  # type: ignore[attr-defined]
             robot.cell = self.model.warehouse[  # type: ignore[attr-defined]
@@ -174,7 +177,10 @@ class WorkerAgent(mesa.Agent):
             else:
                 robot.path = robot.find_path(robot.cell, robot.loading_dock)  # type: ignore[attr-defined]
 
-        if status == "movement complete" and getattr(robot, "status", None) == "loading":
+        if (
+            status == "movement complete"
+            and getattr(robot, "status", None) == "loading"
+        ):
             robot.carrying = None  # type: ignore[attr-defined]
             robot.status = "open"  # type: ignore[attr-defined]
             robot.path = None  # type: ignore[attr-defined]

--- a/examples/warehouse/warehouse/agents.py
+++ b/examples/warehouse/warehouse/agents.py
@@ -112,7 +112,7 @@ class SensorAgent(mesa.Agent):
 
 
 class WorkerAgent(mesa.Agent):
-    """Handle inverntory pickup and delivery to the loading dock."""
+    """Handle inventory pickup and delivery to the loading dock."""
 
     def __init__(self, model, ld, cs):
         super().__init__(model)

--- a/examples/warehouse/warehouse/agents.py
+++ b/examples/warehouse/warehouse/agents.py
@@ -1,3 +1,7 @@
+"""Agents used by warehouse meta-agent example."""
+
+from __future__ import annotations
+
 from queue import PriorityQueue
 
 import mesa
@@ -11,20 +15,17 @@ class InventoryAgent(FixedAgent):
         super().__init__(model)
         self.cell = cell
         self.item = item
-        self.quantity = 1000  # Default quantity
+        self.quantity = 1000
 
 
 class RouteAgent(mesa.Agent):
-    """Handles path finding for agents in the warehouse.
-
-    Intended to be a pseudo onboard GPS system for robots.
-    """
+    """Handle path finding for the warehouse robots."""
 
     def __init__(self, model):
         super().__init__(model)
 
     def find_path(self, start, goal) -> list[tuple[int, int, int]] | None:
-        """Determines the path for a robot to take using the A* algorithm."""
+        """Find a path from ``start`` to ``goal`` using A* search."""
 
         def heuristic(a, b) -> int:
             dx = abs(a[0] - b[0])
@@ -46,19 +47,19 @@ class RouteAgent(mesa.Agent):
                     current = came_from[current]
                 path.reverse()
                 path.insert(0, start.coordinate)
-                path.pop()  # Remove the last location (inventory)
+                path.pop()
                 return path
 
             for n_cell in self.model.warehouse[current].neighborhood:
                 coord = n_cell.coordinate
 
-                # Only consider orthogonal neighbors
+                # Only consider orthogonal neighbors in x/y plane.
                 if abs(coord[0] - current[0]) + abs(coord[1] - current[1]) != 1:
                     continue
 
                 tentative_g_score = g_score[current] + 1
                 if not n_cell.is_empty:
-                    tentative_g_score += 50  # Penalty for non-empty cells
+                    tentative_g_score += 50
 
                 if coord not in g_score or tentative_g_score < g_score[coord]:
                     g_score[coord] = tentative_g_score
@@ -70,10 +71,7 @@ class RouteAgent(mesa.Agent):
 
 
 class SensorAgent(mesa.Agent):
-    """Detects entities in the area and handles movement along a path.
-
-    Intended to be a pseudo onboard sensor system for robot.
-    """
+    """Detect obstacles and move the robot along a computed path."""
 
     def __init__(self, model):
         super().__init__(model)
@@ -81,7 +79,10 @@ class SensorAgent(mesa.Agent):
     def move(
         self, coord: tuple[int, int, int], path: list[tuple[int, int, int]]
     ) -> str:
-        """Moves the agent along the given path."""
+        """Move one step along the current path."""
+        # Backend-authoritative lookup: sensor -> robot via groups_of
+        robot = next(iter(self.model.meta_agents.groups_of(self)), self)
+
         if coord not in path:
             raise ValueError("Current coordinate not in path.")
 
@@ -91,25 +92,27 @@ class SensorAgent(mesa.Agent):
 
         next_cell = self.model.warehouse[path[idx + 1]]
         if next_cell.is_empty:
-            self.meta_agent.cell = next_cell
+            robot.cell = next_cell  # type: ignore[attr-defined]
             return "moving"
 
-        # Handle obstacle
-        neighbors = self.model.warehouse[self.meta_agent.cell.coordinate].neighborhood
+        neighbors = self.model.warehouse[robot.cell.coordinate].neighborhood  # type: ignore[attr-defined]
         empty_neighbors = [n for n in neighbors if n.is_empty]
         if empty_neighbors:
-            self.meta_agent.cell = self.random.choice(empty_neighbors)
+            robot.cell = self.random.choice(empty_neighbors)  # type: ignore[attr-defined]
 
-        # Recalculate path
-        new_path = self.meta_agent.get_constituting_agent_instance(
-            RouteAgent
-        ).find_path(self.meta_agent.cell, self.meta_agent.item.cell)
-        self.meta_agent.path = new_path
+        # Recalculate via typed router member
+        router = next(
+            iter(self.model.meta_agents.members_of(robot, relation="router")), None
+        )
+        if router is None or getattr(robot, "item", None) is None:
+            return "recalculating"
+        new_path = router.find_path(robot.cell, robot.item.cell)  # type: ignore[attr-defined]
+        robot.path = new_path  # type: ignore[attr-defined]
         return "recalculating"
 
 
 class WorkerAgent(mesa.Agent):
-    """Represents a robot worker responsible for collecting and loading items."""
+    """Handle inverntory pickup and delivery to the loading dock."""
 
     def __init__(self, model, ld, cs):
         super().__init__(model)
@@ -120,33 +123,59 @@ class WorkerAgent(mesa.Agent):
         self.item: InventoryAgent | None = None
 
     def initiate_task(self, item: InventoryAgent):
-        """Initiates a task for the robot to perform."""
-        self.item = item
-        self.path = self.find_path(self.cell, item.cell)
+        """Start a new inventory task."""
+        robot = next(iter(self.model.meta_agents.groups_of(self)), self)
+        # Typed lookup for router to build path
+        router = next(
+            iter(self.model.meta_agents.members_of(robot, relation="router")), None
+        )
+        robot.item = item  # type: ignore[attr-defined]
+        if router is not None:
+            robot.path = router.find_path(robot.cell, item.cell)  # type: ignore[attr-defined]
+        else:
+            # fallback: router capability assumed on robot via meta_methods
+            robot.path = robot.find_path(robot.cell, item.cell)  # type: ignore[attr-defined]
 
     def continue_task(self):
-        """Continues the task if the robot is able to perform it."""
-        status = self.meta_agent.get_constituting_agent_instance(SensorAgent).move(
-            self.cell.coordinate, self.path
-        )
+        """Continue the current task if the robot has one."""
+        robot = next(iter(self.model.meta_agents.groups_of(self)), self)
+        if getattr(robot, "path", None) is None or getattr(robot, "item", None) is None:
+            return
 
-        if status == "movement complete" and self.meta_agent.status == "inventory":
-            # Pick up item and bring to loading dock
-            source_coordinate = self.meta_agent.cell.coordinate
-            target_level = self.item.cell.coordinate[2]
-            self.meta_agent.cell = self.model.warehouse[
+        sensor = next(
+            iter(self.model.meta_agents.members_of(robot, relation="sensor")), None
+        )
+        if sensor is not None:
+            status = sensor.move(robot.cell.coordinate, robot.path)  # type: ignore[arg-type]
+        else:
+            # fallback to robot's own move (wired via meta_methods)
+            status = robot.move(robot.cell.coordinate, robot.path)  # type: ignore[attr-defined]
+
+        if status == "movement complete" and getattr(robot, "status", None) == "inventory":
+            source_coordinate = robot.cell.coordinate  # type: ignore[attr-defined]
+            target_level = robot.item.cell.coordinate[2]  # type: ignore[attr-defined]
+            robot.cell = self.model.warehouse[  # type: ignore[attr-defined]
                 (source_coordinate[0], source_coordinate[1], target_level)
             ]
-            self.meta_agent.status = "loading"
-            self.carrying = self.item.item
-            self.item.quantity -= 1
-            loading_coordinate = self.meta_agent.cell.coordinate
-            self.meta_agent.cell = self.model.warehouse[
+            robot.status = "loading"  # type: ignore[attr-defined]
+            robot.carrying = robot.item.item  # type: ignore[attr-defined]
+            robot.item.quantity -= 1  # type: ignore[attr-defined]
+
+            loading_coordinate = robot.cell.coordinate  # type: ignore[attr-defined]
+            robot.cell = self.model.warehouse[  # type: ignore[attr-defined]
                 (loading_coordinate[0], loading_coordinate[1], 0)
             ]
-            self.path = self.find_path(self.cell, self.loading_dock)
+            # Recompute path to loading dock via router or robot
+            router = next(
+                iter(self.model.meta_agents.members_of(robot, relation="router")), None
+            )
+            if router is not None:
+                robot.path = router.find_path(robot.cell, robot.loading_dock)  # type: ignore[attr-defined]
+            else:
+                robot.path = robot.find_path(robot.cell, robot.loading_dock)  # type: ignore[attr-defined]
 
-        if status == "movement complete" and self.meta_agent.status == "loading":
-            # Load item onto truck and return to charging station
-            self.carrying = None
-            self.meta_agent.status = "open"
+        if status == "movement complete" and getattr(robot, "status", None) == "loading":
+            robot.carrying = None  # type: ignore[attr-defined]
+            robot.status = "open"  # type: ignore[attr-defined]
+            robot.path = None  # type: ignore[attr-defined]
+            robot.item = None  # type: ignore[attr-defined]

--- a/examples/warehouse/warehouse/make_warehouse.py
+++ b/examples/warehouse/warehouse/make_warehouse.py
@@ -1,51 +1,47 @@
+"""Generate a compact warehouse layout for the meta-agent example."""
+
+from __future__ import annotations
+
 import random
 import string
+from random import Random
 
 import numpy as np
 
-# Constants
-DEFAULT_ROWS = 22
-DEFAULT_COLS = 20
-DEFAULT_HEIGHT = 4
-LOADING_DOCK_COORDS = [(0, i, 0) for i in range(0, 10, 2)]
-CHARGING_STATION_COORDS = [(21, i, 0) for i in range(19, 10, -2)]
+DEFAULT_ROWS = 8
+DEFAULT_COLS = 8
+DEFAULT_HEIGHT = 2
+LOADING_DOCK_COORDS = [(0, 0, 0), (0, 2, 0)]
+CHARGING_STATION_COORDS = [(7, 5, 0), (7, 7, 0)]
 
 
-def generate_item_code() -> str:
-    """Generate a random item code (1 letter + 2 numbers)."""
-    letter = random.choice(string.ascii_uppercase)
-    number = random.randint(10, 99)
+def generate_item_code(rng: Random) -> str:
+    """Generate a short random inventory code."""
+    letter = rng.choice(string.ascii_uppercase)
+    number = rng.randint(10, 99)
     return f"{letter}{number}"
 
 
 def make_warehouse(
-    rows: int = DEFAULT_ROWS, cols: int = DEFAULT_COLS, height: int = DEFAULT_HEIGHT
+    rows: int = DEFAULT_ROWS,
+    cols: int = DEFAULT_COLS,
+    height: int = DEFAULT_HEIGHT,
+    rng: Random | None = None,
 ) -> np.ndarray:
-    """Generate a warehouse layout with designated LD, CS, and storage rows as a NumPy array.
+    """Generate a 3D warehouse array with loading docks and inventory."""
+    rng = rng or random.Random(0)
 
-    Args:
-        rows (int): Number of rows in the warehouse.
-        cols (int): Number of columns in the warehouse.
-        height (int): Number of levels in the warehouse.
+    warehouse = np.full((rows, cols, height), " ", dtype=object)
 
-    Returns:
-        np.ndarray: A 3D NumPy array representing the warehouse layout.
-    """
-    # Initialize empty warehouse layout
-    warehouse = np.full((rows, cols, height), "  ", dtype=object)
-
-    # Place Loading Docks (LD)
     for r, c, h in LOADING_DOCK_COORDS:
         warehouse[r, c, h] = "LD"
 
-    # Place Charging Stations (CS)
     for r, c, h in CHARGING_STATION_COORDS:
         warehouse[r, c, h] = "CS"
 
-    # Fill storage rows with item codes
-    for r in range(3, rows - 2, 3):  # Skip row 0,1,2 (LD) and row 17,18,19 (CS)
-        for c in range(2, cols, 3):  # Leave 2 spaces between each item row
+    for r in range(2, rows - 1, 3):
+        for c in range(1, cols, 3):
             for h in range(height):
-                warehouse[r, c, h] = generate_item_code()
+                warehouse[r, c, h] = generate_item_code(rng)
 
     return warehouse

--- a/examples/warehouse/warehouse/make_warehouse.py
+++ b/examples/warehouse/warehouse/make_warehouse.py
@@ -8,11 +8,40 @@ from random import Random
 
 import numpy as np
 
-DEFAULT_ROWS = 8
-DEFAULT_COLS = 8
-DEFAULT_HEIGHT = 2
-LOADING_DOCK_COORDS = [(0, 0, 0), (0, 2, 0)]
-CHARGING_STATION_COORDS = [(7, 5, 0), (7, 7, 0)]
+
+def get_warehouse_coords(
+    rows: int, cols: int
+) -> tuple[list[tuple[int, int, int]], list[tuple[int, int, int]]]:
+    """Return loading-dock and charging-station coordinates for a size.
+
+    Keeps the two dock/station pairs used by the example but adapts column
+    placement when ``cols`` differs from the default 8. Inventory lives at
+    ``cols 1,4,7,...`` (see ``range(1, cols, 3)``), so docks at ``0`` and ``2``
+    and stations at ``cols-1`` and ``cols-3`` avoid direct overlap.
+    """
+    if rows < 4 or cols < 4:
+        raise ValueError(f"Warehouse too small: rows={rows} cols={cols} need >=4")
+
+    # Loading docks on the north edge (row 0). Keep two, spaced by 2.
+    docks: list[tuple[int, int, int]] = [(0, 0, 0)]
+    if cols > 2:
+        docks.append((0, 2, 0))
+    # For wider warehouses we could add more, but the example is fixed at 2.
+    docks = docks[:2]
+
+    # Charging stations on the south edge (row rows-1), right side.
+    stations: list[tuple[int, int, int]] = []
+    if cols >= 2:
+        stations.append((rows - 1, cols - 1, 0))
+    if cols >= 4:
+        stations.append((rows - 1, cols - 3, 0))
+    # Ensure ordering matches docks (first dock ↔ last station spacing)
+    stations = list(reversed(stations[:2]))
+    if len(stations) == 1 and len(docks) == 2:
+        # Degenerate narrow warehouse - duplicate the single station.
+        stations.append(stations[0])
+
+    return docks, stations
 
 
 def generate_item_code(rng: Random) -> str:
@@ -23,25 +52,35 @@ def generate_item_code(rng: Random) -> str:
 
 
 def make_warehouse(
-    rows: int = DEFAULT_ROWS,
-    cols: int = DEFAULT_COLS,
-    height: int = DEFAULT_HEIGHT,
+    rows: int,
+    cols: int,
+    height: int,
     rng: Random | None = None,
 ) -> np.ndarray:
-    """Generate a 3D warehouse array with loading docks and inventory."""
+    """Generate a 3D warehouse array with loading docks and inventory.
+
+    Sizes come from ``WarehouseScenario`` (``rows``, ``cols``, ``height``);
+    this module holds no independent defaults.
+    """
     rng = rng or random.Random(0)
 
     warehouse = np.full((rows, cols, height), " ", dtype=object)
 
-    for r, c, h in LOADING_DOCK_COORDS:
+    docks, stations = get_warehouse_coords(rows, cols)
+
+    for r, c, h in docks:
         warehouse[r, c, h] = "LD"
 
-    for r, c, h in CHARGING_STATION_COORDS:
+    for r, c, h in stations:
         warehouse[r, c, h] = "CS"
 
     for r in range(2, rows - 1, 3):
         for c in range(1, cols, 3):
             for h in range(height):
+                # Don't overwrite docks/stations (edge rows/cols already handled,
+                # but keep guard for small warehouses).
+                if warehouse[r, c, h] != " ":
+                    continue
                 warehouse[r, c, h] = generate_item_code(rng)
 
     return warehouse

--- a/examples/warehouse/warehouse/model.py
+++ b/examples/warehouse/warehouse/model.py
@@ -18,7 +18,9 @@ from .make_warehouse import (
 
 def _robot_find_path(self, start, goal):  # type: ignore[no-untyped-def]
     """Delegate path finding to the typed ``router`` member."""
-    router = next(iter(self.model.meta_agents.members_of(self, relation="router")), None)
+    router = next(
+        iter(self.model.meta_agents.members_of(self, relation="router")), None
+    )
     if router is None:
         raise RuntimeError("Robot has no router member")
     return router.find_path(start, goal)
@@ -26,7 +28,9 @@ def _robot_find_path(self, start, goal):  # type: ignore[no-untyped-def]
 
 def _robot_move(self, coord, path):  # type: ignore[no-untyped-def]
     """Delegate movement to the typed ``sensor`` member."""
-    sensor = next(iter(self.model.meta_agents.members_of(self, relation="sensor")), None)
+    sensor = next(
+        iter(self.model.meta_agents.members_of(self, relation="sensor")), None
+    )
     if sensor is None:
         raise RuntimeError("Robot has no sensor member")
     return sensor.move(coord, path)
@@ -34,7 +38,9 @@ def _robot_move(self, coord, path):  # type: ignore[no-untyped-def]
 
 def _robot_initiate_task(self, item):  # type: ignore[no-untyped-def]
     """Delegate task start to the typed ``worker`` member."""
-    worker = next(iter(self.model.meta_agents.members_of(self, relation="worker")), None)
+    worker = next(
+        iter(self.model.meta_agents.members_of(self, relation="worker")), None
+    )
     if worker is None:
         raise RuntimeError("Robot has no worker member")
     return worker.initiate_task(item)
@@ -42,7 +48,9 @@ def _robot_initiate_task(self, item):  # type: ignore[no-untyped-def]
 
 def _robot_continue_task(self):  # type: ignore[no-untyped-def]
     """Delegate task continuation to the typed ``worker`` member."""
-    worker = next(iter(self.model.meta_agents.members_of(self, relation="worker")), None)
+    worker = next(
+        iter(self.model.meta_agents.members_of(self, relation="worker")), None
+    )
     if worker is None:
         raise RuntimeError("Robot has no worker member")
     return worker.continue_task()

--- a/examples/warehouse/warehouse/model.py
+++ b/examples/warehouse/warehouse/model.py
@@ -9,11 +9,7 @@ from mesa.experimental.scenarios import Scenario
 from mesa.meta_agents import MetaAgents
 
 from .agents import InventoryAgent, RouteAgent, SensorAgent, WorkerAgent
-from .make_warehouse import (
-    CHARGING_STATION_COORDS,
-    LOADING_DOCK_COORDS,
-    make_warehouse,
-)
+from .make_warehouse import get_warehouse_coords, make_warehouse
 
 
 def _robot_find_path(self, start, goal):  # type: ignore[no-untyped-def]
@@ -67,14 +63,14 @@ class WarehouseScenario(Scenario):
 class WarehouseModel(mesa.Model):
     """Model for simulating warehouse robots assembled from sub-agents."""
 
-    def __init__(self, scenario: WarehouseScenario = WarehouseScenario, rng=42):
+    def __init__(self, scenario: WarehouseScenario = WarehouseScenario):  # type: ignore[assignment]
         """Create the warehouse, inventory, and robot meta-agents."""
-        if isinstance(scenario, Scenario):
-            super().__init__(scenario=scenario)
-        else:
-            super().__init__(scenario=scenario, rng=rng)
+        super().__init__(scenario=scenario)
         self.inventory = {}
         self.meta_agents = MetaAgents(self)
+        # Expose backend for shallow inspection (triplet count, invariants).
+        # Most code should use self.meta_agents; this alias shows the
+        # underlying MembershipBackend that tracks triplets.
         self.membership_backend = self.meta_agents.backend
 
         layout = make_warehouse(
@@ -98,12 +94,17 @@ class WarehouseModel(mesa.Model):
                     if item.strip():
                         InventoryAgent(self, self.warehouse[row, col, height], item)
 
-        self.robot_agent_type: type | None = None
-        self.RobotAgent = None
+        self.robots: list = []
 
-        # One robot is created per loading dock / charging station pair.
-        for loading_dock, charging_station in zip(
-            LOADING_DOCK_COORDS, CHARGING_STATION_COORDS, strict=True
+        # One robot per dock/station pair; coords adapt to scenario size.
+        loading_docks, charging_stations = get_warehouse_coords(
+            self.scenario.rows, self.scenario.cols
+        )
+        self.loading_docks = loading_docks
+        self.charging_stations = charging_stations
+
+        for idx, (loading_dock, charging_station) in enumerate(
+            zip(loading_docks, charging_stations, strict=True)
         ):
             router = RouteAgent(self)
             sensor = SensorAgent(self)
@@ -113,8 +114,15 @@ class WarehouseModel(mesa.Model):
                 self.warehouse[charging_station],
             )
 
+            # Unique class name per robot keeps string lookups unambiguous
+            # (mesa warns that reusing the same name with disjoint members
+            # creates distinct groups with the same name). For this shallow
+            # example we keep two robots; unique names mirror
+            # alliance_formation's f"MetaAgentLevel{level}_{sig}" pattern.
+            class_name = f"RobotAgent_{idx}"
+
             meta = self.meta_agents.create(
-                "RobotAgent",
+                class_name,
                 [router, sensor, worker],
                 CellAgent,
                 meta_attributes={
@@ -142,21 +150,28 @@ class WarehouseModel(mesa.Model):
             if meta is None:
                 continue
 
-            if self.robot_agent_type is None:
-                self.robot_agent_type = type(meta)
-
-            self.RobotAgent = meta
+            self.robots.append(meta)
 
     def central_move(self, robot):
         """Delegate path execution to the robot's worker role."""
         robot.move(robot.cell.coordinate, robot.path)
 
+    @property
+    def triplet_count(self) -> int:
+        """Number of membership triplets tracked by the backend."""
+
+        return len(self.membership_backend.as_triplets())
+
     def step(self):
         """Advance the model by one step."""
-        if self.robot_agent_type is None:
+        # Iterate over the explicit robot list so unique class names
+        # (RobotAgent_0, RobotAgent_1) both get stepped. Using
+        # agents_by_type would only cover the first type when names are
+        # unique.
+        if not self.robots:
             return
 
-        for robot in self.agents_by_type[self.robot_agent_type]:
+        for robot in list(self.robots):
             agent_list = self.agents_by_type[InventoryAgent].to_list()
 
             if robot.status == "open":

--- a/examples/warehouse/warehouse/model.py
+++ b/examples/warehouse/warehouse/model.py
@@ -1,47 +1,80 @@
+"""Warehouse meta-agent example built on the public meta-agents API."""
+
+from __future__ import annotations
+
 import mesa
 from mesa.discrete_space import OrthogonalMooreGrid
 from mesa.discrete_space.cell_agent import CellAgent
-from mesa.experimental.meta_agents.meta_agent import create_meta_agent
+from mesa.experimental.scenarios import Scenario
+from mesa.meta_agents import MetaAgents
 
-from .agents import (
-    InventoryAgent,
-    RouteAgent,
-    SensorAgent,
-    WorkerAgent,
+from .agents import InventoryAgent, RouteAgent, SensorAgent, WorkerAgent
+from .make_warehouse import (
+    CHARGING_STATION_COORDS,
+    LOADING_DOCK_COORDS,
+    make_warehouse,
 )
-from .make_warehouse import make_warehouse
 
-# Constants for configuration
-LOADING_DOCKS = [(0, 0, 0), (0, 2, 0), (0, 4, 0), (0, 6, 0), (0, 8, 0)]
-CHARGING_STATIONS = [
-    (21, 19, 0),
-    (21, 17, 0),
-    (21, 15, 0),
-    (21, 13, 0),
-    (21, 11, 0),
-]
-INVENTORY_START_ROW_OFFSET = 3
+
+def _robot_find_path(self, start, goal):  # type: ignore[no-untyped-def]
+    """Delegate path finding to the typed ``router`` member."""
+    router = next(iter(self.model.meta_agents.members_of(self, relation="router")), None)
+    if router is None:
+        raise RuntimeError("Robot has no router member")
+    return router.find_path(start, goal)
+
+
+def _robot_move(self, coord, path):  # type: ignore[no-untyped-def]
+    """Delegate movement to the typed ``sensor`` member."""
+    sensor = next(iter(self.model.meta_agents.members_of(self, relation="sensor")), None)
+    if sensor is None:
+        raise RuntimeError("Robot has no sensor member")
+    return sensor.move(coord, path)
+
+
+def _robot_initiate_task(self, item):  # type: ignore[no-untyped-def]
+    """Delegate task start to the typed ``worker`` member."""
+    worker = next(iter(self.model.meta_agents.members_of(self, relation="worker")), None)
+    if worker is None:
+        raise RuntimeError("Robot has no worker member")
+    return worker.initiate_task(item)
+
+
+def _robot_continue_task(self):  # type: ignore[no-untyped-def]
+    """Delegate task continuation to the typed ``worker`` member."""
+    worker = next(iter(self.model.meta_agents.members_of(self, relation="worker")), None)
+    if worker is None:
+        raise RuntimeError("Robot has no worker member")
+    return worker.continue_task()
+
+
+class WarehouseScenario(Scenario):
+    """Scenario parameters for the warehouse meta-agent example."""
+
+    rows: int = 8
+    cols: int = 8
+    height: int = 2
 
 
 class WarehouseModel(mesa.Model):
-    """Model for simulating warehouse management with autonomous systems where
-    each autonomous system (e.g., robot) is made of numerous smaller agents
-    (e.g., routing, sensors, etc.).
-    """
+    """Model for simulating warehouse robots assembled from sub-agents."""
 
-    def __init__(self, rng=42):
-        """Initialize the model.
-
-        Args:
-            rng (int): Random number generator.
-        """
-        super().__init__(rng=rng)
+    def __init__(self, scenario: WarehouseScenario = WarehouseScenario, rng=42):
+        """Create the warehouse, inventory, and robot meta-agents."""
+        if isinstance(scenario, Scenario):
+            super().__init__(scenario=scenario)
+        else:
+            super().__init__(scenario=scenario, rng=rng)
         self.inventory = {}
-        self.loading_docks = LOADING_DOCKS
-        self.charging_stations = CHARGING_STATIONS
+        self.meta_agents = MetaAgents(self)
+        self.membership_backend = self.meta_agents.backend
 
-        # Create warehouse and instantiate grid
-        layout = make_warehouse()
+        layout = make_warehouse(
+            rows=self.scenario.rows,
+            cols=self.scenario.cols,
+            height=self.scenario.height,
+            rng=self.random,
+        )
         self.warehouse = OrthogonalMooreGrid(
             (layout.shape[0], layout.shape[1], layout.shape[2]),
             torus=False,
@@ -49,59 +82,81 @@ class WarehouseModel(mesa.Model):
             random=self.random,
         )
 
-        # Create Inventory Agents
-        for row in range(
-            INVENTORY_START_ROW_OFFSET, layout.shape[0] - INVENTORY_START_ROW_OFFSET
-        ):
+        # Inventory agents live in the storage rows of the warehouse.
+        for row in range(2, layout.shape[0] - 1, 3):
             for col in range(layout.shape[1]):
                 for height in range(layout.shape[2]):
-                    if layout[row][col][height].strip():
-                        item = layout[row][col][height]
+                    item = layout[row][col][height]
+                    if item.strip():
                         InventoryAgent(self, self.warehouse[row, col, height], item)
 
-        # Create Robot Agents
-        for idx in range(len(self.loading_docks)):
-            # Create constituting_agents
+        self.robot_agent_type: type | None = None
+        self.RobotAgent = None
+
+        # One robot is created per loading dock / charging station pair.
+        for loading_dock, charging_station in zip(
+            LOADING_DOCK_COORDS, CHARGING_STATION_COORDS, strict=True
+        ):
             router = RouteAgent(self)
             sensor = SensorAgent(self)
             worker = WorkerAgent(
                 self,
-                self.warehouse[self.loading_docks[idx]],
-                self.warehouse[self.charging_stations[idx]],
+                self.warehouse[loading_dock],
+                self.warehouse[charging_station],
             )
 
-            # Create meta-agent and place in warehouse
-            self.RobotAgent = create_meta_agent(
-                self,
+            meta = self.meta_agents.create(
                 "RobotAgent",
                 [router, sensor, worker],
                 CellAgent,
                 meta_attributes={
-                    "cell": self.warehouse[self.charging_stations[idx]],
+                    "cell": self.warehouse[charging_station],
                     "status": "open",
+                    "path": None,
+                    "item": None,
+                    "carrying": None,
+                    "loading_dock": self.warehouse[loading_dock],
+                    "charging_station": self.warehouse[charging_station],
                 },
-                assume_constituting_agent_attributes=True,
-                assume_constituting_agent_methods=True,
+                meta_methods={
+                    "find_path": _robot_find_path,
+                    "move": _robot_move,
+                    "initiate_task": _robot_initiate_task,
+                    "continue_task": _robot_continue_task,
+                },
+                memberships=[
+                    (router, "router"),
+                    (sensor, "sensor"),
+                    (worker, "worker"),
+                ],
             )
 
-    def central_move(self, robot):
-        """Consolidates meta-agent behavior in the model class.
+            if meta is None:
+                continue
 
-        Args:
-            robot: The robot meta-agent to move.
-        """
+            if self.robot_agent_type is None:
+                self.robot_agent_type = type(meta)
+
+            self.RobotAgent = meta
+
+    def central_move(self, robot):
+        """Delegate path execution to the robot's worker role."""
         robot.move(robot.cell.coordinate, robot.path)
 
     def step(self):
         """Advance the model by one step."""
-        for robot in self.agents_by_type[type(self.RobotAgent)]:
+        if self.robot_agent_type is None:
+            return
+
+        for robot in self.agents_by_type[self.robot_agent_type]:
             agent_list = self.agents_by_type[InventoryAgent].to_list()
 
-            if robot.status == "open":  # Assign a task to the robot
+            if robot.status == "open":
                 item = self.random.choice(agent_list)
                 if item.quantity > 0:
                     robot.initiate_task(item)
                     robot.status = "inventory"
                     self.central_move(robot)
+
             else:
                 robot.continue_task()


### PR DESCRIPTION
> [!NOTE]
> This PR is a part of GSoC 2026 project ["Hypergraph-Based Meta-Agents for Mesa"](https://summerofcode.withgoogle.com/programs/2026/projects/8Rhd5XVJ)
> A detailed write-up is available [here](https://gist.github.com/falloficaruss/50188788e106cb766d4764fbbfe3d491)

### Summary

This PR ports the warehouse example, the deliberate meta-agent creation showcase in mesa-examples from the removed experimental API (`mesa.experimental.meta_agents.create_meta_agent`) to the new **backend-authoritative MetaAgents** manager introduced in mesa/mesa#3811 (`mesa.meta_agents`).
mesa/mesa#3811 removes the old implementation outright (no shim), consistent with the Mesa 4.0 breaking-change window. The old API scattered membership state across live objects (meta_agent.constituting_agents, agent.meta_agent, get_constituting_agent_instance(...), assume_constituting_agent_*). The new API makes the model-level `MetaAgents` manager the single write path, with all memberships stored as (member, group, relation) triplets in a canonical incidence backend. This example is rewritten to exercise that public surface: deliberate creation with overlapping memberships, and member <--> group resolution through the manager instead of object pointers.

### Changes

**warehouse/model.py**

- Imports `MetaAgents` from the new top-level `mesa.meta_agents` package (replaces `mesa.experimental.meta_agents.meta_agent.create_meta_agent`).
- Installs the manager once per model: `self.meta_agents = MetaAgents(self)` (and exposes `self.membership_backend`).
- Robots are now assembled via `self.meta_agents.create("RobotAgent", [router, sensor, worker], CellAgent, ...)` with:
  - `meta_attributes`: explicit group state: cell, status, path, item, carrying, loading_dock, charging_station (replaces the implicit assume_constituting_agent_attributes=True behavior, which no longer exists).
  - `meta_methods`: find_path, move, initiate_task, continue_task are thin delegators that resolve the responsible sub-agent through the manager via typed relations (members_of(robot, relation="router" | "sensor" | "worker")).
- `memberships=[(router, "router"), (sensor, "sensor"), (worker, "worker")]` overlapping relation labels recorded in the backend, demonstrating multi-role membership for the same agent–group pair set.
- The dynamically created robot class is tracked as `model.robot_agent_type` instead of the fragile `type(model.RobotAgent)` pattern called out in the old Readme; step() iterates `self.agents_by_type[self.robot_agent_type]` and no-ops gracefully if no robots exist.
- Adds `WarehouseScenario` (subclass of Scenario) with rows / cols / height, so warehouse size is a first-class model parameter; layout generation now uses the scenario dimensions and the model's rng for reproducible item codes.
- One robot is created per loading dock / charging station pair (`zip(..., strict=True)`).
 
**warehouse/agents.py**

- All `self.meta_agent / get_constituting_agent_instance(...)` lookups are replaced with backend-authoritative queries:
  - sub-agent -> its `robot: model.meta_agents.groups_of(self)`
  - robot -> sibling component: `model.meta_agents.members_of(robot, relation=...)`
- `SensorAgent.move` resolves its parent robot and the router member for obstacle re-routing; `WorkerAgent.initiate_task` / `continue_task` resolve router/sensor members for pathing and movement, with fallbacks to the robot's own meta_methods.
- Task completion now resets group state (path, item) so robots return to "open" cleanly.

**warehouse/make_warehouse.py**

- Compact default layout: 8×8×2 (was 22×20×4) with 2 loading docks and 2 charging stations (hence 2 robots), keeping the example quick to run and easy to visualize.
- `make_warehouse()` accepts an rng parameter; item codes are generated from the model's seeded RNG instead of the global random module.

**app.py**

- `LOADING_DOCKS` is now imported from `make_warehouse.LOADING_DOCK_COORDS` (single source of truth; no duplicated coordinate constants).
- Axis limits updated to the compact layout; robots are drawn via `model.robot_agent_type`, with a guard for `robot_agent_type` is `None`.

**warehouse/__init__.py / Readme.md**

- Package exports `WarehouseModel` and `WarehouseScenario`.
- `Readme` updated: robots assembled with `MetaAgents.create` + typed memberships; notes that the backend supports overlapping memberships (this example still uses one group per robot); robots tracked via `model.robot_agent_type`; layout/size/seed configuration documented; stale file descriptions fixed.
Old -> new API mapping used in this example

| Old | New |
| --- | --- |
| `create_meta_agent(model, name, members, cls, ...)` | `model.meta_agents.create(name, members, cls, ...)` |
| `assume_constituting_agent_attributes=True` | explicit `meta_attributes={...}` |
| `assume_constituting_agent_methods=True` | explicit `meta_methods={...}` delegating to typed members |
| `agent.meta_agent` | `model.meta_agents.groups_of(agent)` |
| `meta_agent.get_constituting_agent_instance(Cls)` | `model.meta_agents.members_of(group, relation=...)` |
| `type(model.RobotAgent)` | `model.robot_agent_type` |

### Behavior

- `robots` are assigned inventory tasks, A*-route to items (with obstacle re-routing via the sensor/router split), pick up, deliver to the loading dock, and return to open status. The visualization renders inventory and robot agents as before.
- Intentional visible change: the default warehouse is smaller (8×8×2, 2 robots) so the example runs fast and fits the Solara canvas without hardcoded 22×20 axis limits.

### Dependencies / Merge Order
- Requires mesa/mesa#3811, should be merged after it.
