### PR TITLE
fix-virusantibodymodel

### DIFF
--- a/examples/virus_antibody/virus_antibody/model.py
+++ b/examples/virus_antibody/virus_antibody/model.py
@@ -115,7 +115,7 @@ class VirusAntibodyModel(Model):
             position=viruses_positions,
             duplication_rate=self.virus_duplication_rate,
             mutation_rate=self.virus_mutation_rate,
-            dna=dna,
+            dna=[dna] * self.initial_viruses,
         )
 
         self.datacollector.collect(self)


### PR DESCRIPTION
closes #488 
 all initial viruses are meant to share one founder strain, broadcast and it explicitly so its length matches n
```python
initial_dna = [self.random.randint(0, 9) for _ in range(3)]
...
VirusAgent.create_agents(
    self,
    num_viruses,
    self.space,
    mutation_rate,
    duplication_rate,
    position=virus_positions,
    dna=[initial_dna] * num_viruses,   # broadcast to all agents
)
```