### PR TITLE
Refactor Deffuant statistics using AgentSet

### DIFF
--- a/examples/deffuant_weisbuch/deffuant_weisbuch/model.py
+++ b/examples/deffuant_weisbuch/deffuant_weisbuch/model.py
@@ -83,11 +83,12 @@ class DeffuantWeisbuchModel(Model):
         self.datacollector.collect(self)
 
     def compute_variance(self):
-        opinions = [agent.opinion for agent in self.agents]  # type: ignore[attr-defined]
-        return statistics.variance(opinions) if opinions else 0
+        if not self.agents:
+            return 0
+        return self.agents.agg("opinion", statistics.variance)
 
     def compute_cluster_count(self, delta: float = 0.01) -> int:
-        opinions = sorted(agent.opinion for agent in self.agents)  # type: ignore[attr-defined]
+        opinions = sorted(self.agents.get("opinion"))
 
         if not opinions:
             return 0


### PR DESCRIPTION
## Summary

Updates the Deffuant-Weisbuch example to use the AgentSet API for opinion statistics.

- Uses `agg()` for variance computation.
- Uses `get()` when computing the cluster count.
- Preserves the existing behavior for an empty population.

Related to #111.

## Testing

- `python -m pytest -q test_examples.py -k Deffuant`
- Checked variance and cluster-count results against the previous implementation