### PR TITLE
Add thermostat house example demonstrating continuous states (#492)

### DIFF
--- a/examples/thermostat_house/README.md
+++ b/examples/thermostat_house/README.md
@@ -1,0 +1,58 @@
+# Thermostat House
+
+A house with one room under hysteresis thermostat control, built entirely on
+Mesa's experimental continuous-time APIs.
+
+## Summary
+
+The room temperature is a `ContinuousState`: it stores a base value and a
+rate of change, and extrapolates the current value whenever it is read. Two
+`Threshold`s watch it analytically - the heater comes on when the temperature
+falls to `setpoint - hysteresis` and goes off when it rises to
+`setpoint + hysteresis`. Each crossing is computed in advance and scheduled
+as exactly one event on the model's event queue, so the room never steps or
+polls: the only `step()` in the model samples data for the plots.
+
+The thermostat is fully reactive. The limits are `Observable`s derived from
+the setpoint and deadband, so dragging the setpoint slider mid-run rewrites
+the limits and the thresholds re-arm themselves without any explicit call.
+
+### Mesa experimental APIs demonstrated
+
+| Feature | Usage |
+|---|---|
+| `ContinuousState` | Room temperature stored as base value + rate, extrapolated analytically |
+| `Threshold` | Exact, analytically computed crossing times for heating on/off events |
+| Reactive limits | Thresholds bound to `Observable` limits re-arm when the dials move |
+| `Observable` | Heater state, temperature rate and thermostat dials as signal-emitting fields |
+| `Scenario` | Model parameters (`setpoint`, `hysteresis`, rates) as a typed scenario |
+
+## How to run
+
+```bash
+pip install "mesa @ git+https://github.com/mesa/mesa@main"
+python model.py
+```
+
+Runs the simulation for 50 time units, prints the sampled temperature series
+and asserts the temperature stayed inside the deadband throughout.
+
+## Visualisation
+
+```bash
+python -m solara run app.py
+```
+
+Two lines and a status readout: the temperature swinging between the dials,
+the setpoint, and the heater's on/off state.
+
+## Files
+
+| File | Description |
+|---|---|
+| `agents.py` | `Room` agent: temperature state, thermostat thresholds, heater |
+| `model.py` | `ThermostatHouse` model |
+| `app.py` | Solara visualization |
+
+This example builds against Mesa main (commit `a5dfcd6`, 2026-09-08); the
+`mesa.experimental.*` APIs are pre-release and may change without deprecation.

--- a/examples/thermostat_house/agents.py
+++ b/examples/thermostat_house/agents.py
@@ -1,0 +1,141 @@
+"""Agents for the Thermostat House model."""
+
+from mesa import Agent
+from mesa.experimental.mesa_signals import HasEmitters, Observable, ObservableSignals
+from mesa.experimental.states import ContinuousState, Threshold
+
+HEAT_RATE = 0.25  # °C per time unit while the heater runs
+COOL_RATE = -0.15  # °C per time unit while the house drifts toward outside
+
+
+class Room(Agent, HasEmitters):
+    """A single room whose temperature follows a hysteresis thermostat.
+
+    The temperature is a `ContinuousState` extrapolated analytically between
+    events; heating and cooling are just its rate of change. Two `Threshold`s
+    compute when the temperature will cross the thermostat's limits and
+    schedule exactly one event there, so nothing here steps or polls.
+
+    The limits are `Observable`s fed from the setpoint and the deadband. A
+    Threshold reading an Observable re-arms itself when the limit changes, so
+    turning the dial during a run is picked up without any explicit call.
+
+    Attributes:
+        temperature (ContinuousState): Room temperature, °C.
+        temperature_change_rate (Observable): Current rate of change, °C per time
+            unit. Positive while heating, negative while cooling.
+        heater_on (Observable): Whether the heater is running.
+        setpoint (Observable): Target temperature, °C.
+        hysteresis (Observable): Half-width of the deadband around the
+            setpoint, °C.
+        heat_on_temp (Observable): Limit that turns the heater on on the way
+            down (setpoint - hysteresis).
+        heat_off_temp (Observable): Limit that turns the heater off on the way
+            up (setpoint + hysteresis).
+    """
+
+    temperature = ContinuousState(
+        fallback_value=20.0, rate=lambda a: a.temperature_change_rate
+    )
+    temperature_change_rate = Observable(fallback_value=HEAT_RATE)
+    heater_on = Observable(fallback_value=True)
+    setpoint = Observable(fallback_value=21.0)
+    hysteresis = Observable(fallback_value=0.5)
+    heat_on_temp = Observable(fallback_value=20.5)
+    heat_off_temp = Observable(fallback_value=21.5)
+
+    _heat_off_threshold = Threshold(
+        state=temperature,
+        limit=heat_off_temp,
+        callback="stop_heating",
+        direction="rising",
+    )
+    _heat_on_threshold = Threshold(
+        state=temperature,
+        limit=heat_on_temp,
+        callback="start_heating",
+        direction="falling",
+    )
+
+    def __init__(
+        self,
+        model,
+        temperature: float = 20.0,
+        setpoint: float = 21.0,
+        hysteresis: float = 0.5,
+        heating_rate: float = HEAT_RATE,
+        cooling_rate: float = COOL_RATE,
+    ) -> None:
+        """Create the room.
+
+        Args:
+            model: The model instance that contains the room.
+            temperature: Initial temperature, °C. Defaults to 20.0.
+            setpoint: Target temperature, °C. Defaults to 21.0.
+            hysteresis: Half-width of the deadband around the setpoint, °C.
+                Defaults to 0.5.
+            heating_rate: Temperature rise per time unit while heating, °C.
+                Defaults to HEAT_RATE.
+            cooling_rate: Temperature drop per time unit while cooling, °C.
+                Defaults to COOL_RATE.
+        """
+        super().__init__(model)
+
+        self.heating_rate = heating_rate
+        self.cooling_rate = cooling_rate
+        self.setpoint = setpoint
+        self.hysteresis = hysteresis
+
+        # The limits the thresholds read must exist before the first
+        # ContinuousState assignment, which is what binds the thresholds.
+        self._match_dials()
+
+        # The heater starts in whichever state the dials demand: below the
+        # on-limit it must already be running, above the off-limit it must
+        # already be off.
+        self.heater_on = temperature < self.heat_on_temp
+        self.temperature_change_rate = (
+            self.heating_rate if self.heater_on else self.cooling_rate
+        )
+        self.temperature = temperature
+
+        # Reactive dials: moving the setpoint or the deadband writes new
+        # limits, and the thresholds re-arm themselves from those Observables
+        # while `_rearm` corrects the heater if the jump stranded it.
+        self.observe("setpoint", ObservableSignals.CHANGED, self._rearm)
+        self.observe("hysteresis", ObservableSignals.CHANGED, self._rearm)
+
+    def _match_dials(self, _message=None) -> None:
+        """Rewrite the threshold limits from the setpoint and deadband.
+
+        Called on every dial change; the thresholds observe their limits and
+        re-arm themselves from what this writes.
+        """
+        self.heat_on_temp = self.setpoint - self.hysteresis
+        self.heat_off_temp = self.setpoint + self.hysteresis
+
+    def _rearm(self, _message=None) -> None:
+        """React to a dial change: update the limits and correct any mismatch.
+
+        A threshold only fires on a *crossing*, so a setpoint jump can leave
+        the temperature outside the new deadband with no crossing back toward
+        it in sight. A real thermostat does not wait for that: it turns the
+        heater on if the room is below the on-limit and off if it is above
+        the off-limit, immediately.
+        """
+        self._match_dials()
+        if self.temperature <= self.heat_on_temp:
+            if not self.heater_on:
+                self.start_heating()
+        elif self.temperature >= self.heat_off_temp and self.heater_on:
+            self.stop_heating()
+
+    def stop_heating(self) -> None:
+        """Turn the heater off and let the room cool toward the outside."""
+        self.heater_on = False
+        self.temperature_change_rate = self.cooling_rate
+
+    def start_heating(self) -> None:
+        """Turn the heater on and start warming the room."""
+        self.heater_on = True
+        self.temperature_change_rate = self.heating_rate

--- a/examples/thermostat_house/app.py
+++ b/examples/thermostat_house/app.py
@@ -1,0 +1,47 @@
+"""Solara app for the Thermostat House model.
+
+Run with ``solara run app.py`` from this directory.
+"""
+
+import solara
+from mesa.visualization import Slider, SolaraViz, make_plot_component
+
+try:
+    from .model import ThermostatHouse, ThermostatScenario
+except ImportError:
+    from model import ThermostatHouse, ThermostatScenario
+
+TemperaturePlot = make_plot_component({"Temperature": "#E4572E", "Setpoint": "#17BEBB"})
+HeaterPlot = make_plot_component({"Heater": "#FFC914"})
+
+
+@solara.component
+def thermostat_view(model):
+    """Show the current temperature and heater state."""
+    return solara.Markdown(
+        f"**t = {model.time:.2f}**  ·  temperature = {model.room.temperature:.2f} °C  ·  "
+        f"heater {'on' if model.room.heater_on else 'off'}"
+    )
+
+
+model_params = {
+    "rng": {
+        "type": "InputText",
+        "value": 42,
+        "label": "Random Seed",
+    },
+    "initial_temperature": Slider("Initial temperature (°C)", 20, 0, 40, 1),
+    "setpoint": Slider("Setpoint (°C)", 21, 15, 28, 0.5),
+    "hysteresis": Slider("Deadband half-width (°C)", 0.5, 0.1, 2.0, 0.1),
+}
+
+
+model = ThermostatHouse(scenario=ThermostatScenario())
+
+page = SolaraViz(
+    model,
+    components=[thermostat_view, TemperaturePlot, HeaterPlot],
+    model_params=model_params,
+    name="Thermostat House",
+)
+page  # noqa

--- a/examples/thermostat_house/model.py
+++ b/examples/thermostat_house/model.py
@@ -1,0 +1,113 @@
+"""Thermostat House model.
+
+A single room whose temperature is kept inside a deadband around a target by
+a hysteresis thermostat, built entirely on Mesa's experimental continuous
+states. The temperature is extrapolated analytically and the thermostat's
+turn-on/turn-off events are scheduled exactly when the temperature crosses
+the dials -- there is no step logic at all; `step()` only samples data for
+plotting and can be deleted without changing the temperature curve.
+"""
+
+from mesa import Model
+from mesa.datacollection import DataCollector
+from mesa.experimental.scenarios import Scenario
+
+try:
+    from .agents import Room
+except ImportError:
+    from agents import Room
+
+
+class ThermostatScenario(Scenario):
+    """Scenario for the Thermostat House model.
+
+    Args:
+        initial_temperature: Temperature of the room at t=0, °C.
+        setpoint: Target temperature, °C.
+        hysteresis: Half-width of the deadband around the setpoint, °C.
+        heating_rate: Temperature rise per time unit while heating, °C.
+        cooling_rate: Temperature drop per time unit while cooling, °C.
+    """
+
+    initial_temperature: float = 20.0
+    setpoint: float = 21.0
+    hysteresis: float = 0.5
+    heating_rate: float = 0.25
+    cooling_rate: float = -0.15
+
+
+class ThermostatHouse(Model):
+    """A house with one room under thermostat control.
+
+    Attributes:
+        room (Room): The room and its heating plant.
+    """
+
+    def __init__(self, scenario: ThermostatScenario = ThermostatScenario):
+        """Create the model and its room.
+
+        Args:
+            scenario: ThermostatScenario containing the model parameters.
+        """
+        super().__init__(scenario=scenario)
+
+        self.room = Room(
+            self,
+            temperature=scenario.initial_temperature,
+            setpoint=scenario.setpoint,
+            hysteresis=scenario.hysteresis,
+            heating_rate=scenario.heating_rate,
+            cooling_rate=scenario.cooling_rate,
+        )
+
+        self.datacollector = DataCollector(
+            model_reporters={
+                "Temperature": lambda m: m.room.temperature,
+                "Setpoint": lambda m: m.room.setpoint,
+                "Heater": lambda m: 1.0 if m.room.heater_on else 0.0,
+            }
+        )
+        self.datacollector.collect(self)
+
+    def step(self) -> None:
+        """Sample the temperature once per time unit.
+
+        The room needs no per-step logic: its temperature is extrapolated
+        analytically and the heater flips from analytically computed event
+        times on the event queue. This step exists purely to feed the
+        DataCollector behind the plots.
+        """
+        self.datacollector.collect(self)
+
+
+if __name__ == "__main__":
+    import numpy as np
+
+    model = ThermostatHouse()
+
+    print(
+        f"initial_temperature={model.room.temperature:.1f} °C, "
+        f"setpoint={model.room.setpoint:.1f} °C, "
+        f"hysteresis={model.room.hysteresis:.1f} °C\n"
+    )
+
+    model.run_for(50.0)
+
+    df = model.datacollector.get_model_vars_dataframe()
+    print(df.to_string())
+
+    # The temperature must stay inside the deadband once the room has warmed
+    # into it: the thermostat holds it between setpoint - hysteresis and
+    # setpoint + hysteresis. The first two samples are the cold start, where
+    # the room begins below the band and warms in.
+    low = model.room.setpoint - model.room.hysteresis
+    high = model.room.setpoint + model.room.hysteresis
+    in_band = np.all(
+        (df["Temperature"].iloc[2:] >= low - 1e-9)
+        & (df["Temperature"].iloc[2:] <= high + 1e-9)
+    )
+    print(f"\nFinal time:     {model.time:.2f}")
+    print(f"Final temperature: {model.room.temperature:.2f} °C")
+    print(f"Heater:        {'on' if model.room.heater_on else 'off'}")
+    print(f"Temperature stayed inside [{low:.2f}, {high:.2f}] °C: {in_band}")
+    assert in_band


### PR DESCRIPTION
Closes #492 (idea 5, the thermostat house)

## Summary

A new example demonstrating Mesa's experimental event-driven behavior APIs: `mesa.experimental.states.ContinuousState`, `Threshold` with reactive `Observable` limits, and `Scenario`. This is idea 5 from the issue ("Thermostat house... probably the smallest possible demo, good first contribution").

The room temperature is a `ContinuousState` extrapolated analytically; two `Threshold`s compute when the temperature will cross the thermostat's limits and schedule exactly one event there. There is no polling or per-step control logic: `step()` only samples data for the plots and can be deleted without changing the temperature curve, matching the tram model's style.

Layout follows the usual example structure and the tram model: `agents.py`, `model.py`, `app.py`, `README.md` under `examples/thermostat_house/`.

## Behavior details

- Hysteresis thermostat: heater turns on when the temperature falls to `setpoint - hysteresis`, off when it rises to `setpoint + hysteresis`.
- Reactive dials: the limits are `Observable`s fed from the setpoint and deadband. Changing a dial mid-run re-arms the thresholds automatically, and `_rearm` corrects the heater immediately if the jump strands the temperature on the wrong side of the new deadband (verified for warm jumps, cool jumps and deadband changes).
- The heater starts in whichever state the dials demand (`23 deg C` initial temperature means heater off; `19 deg C` means on).

## Verification

- `pytest test_examples.py -k ThermostatHouse` - PASSED (the repo's auto-runner instantiates the model with no arguments and runs `run_for(10)`).
- `python model.py` runs `run_for(50)` and asserts the temperature stays inside the deadband after the cold-start transient - stays between 20.5 and 21.5 deg C.
- Hand checks: setpoint/ hysteresis changes mid-run hold the new deadband in steady state; hot-start initial state keeps the heater off.
- `ruff check` and `ruff format --check` clean on the example; pre-commit hooks (ruff, pyupgrade, trailing-whitespace, codespell) run clean.
- `app.py` imports cleanly with `solara` and `matplotlib` installed.

## Mesa version

Built against Mesa main commit `a5dfcd6` (2026-09-08). The example uses `mesa.experimental.*` APIs which may change without deprecation.

Note: the `build-pre` CI job installs `mesa[network] --pre`, which currently resolves to the last published release (3.5.1) where `mesa.experimental.states` does not exist yet, so that job cannot pass for any example from this issue; the `build-main` job (`mesa@main` from git) is the one that exercises this example. Happy to adjust if the maintainers prefer a different handling for experimental examples.