### PR TITLE
Fix VirusAntibodyModel giving every virus agent the same shared dna list

### DIFF
--- a/examples/virus_antibody/virus_antibody/model.py
+++ b/examples/virus_antibody/virus_antibody/model.py
@@ -4,6 +4,8 @@ Virus/Antibody Model
 A mesa implementation of the Virus/Antibody model, where antibodies and viruses interact in a continuous space.
 """
 
+import copy
+
 import numpy as np
 from mesa import Model
 from mesa.datacollection import DataCollector
@@ -115,7 +117,7 @@ class VirusAntibodyModel(Model):
             position=viruses_positions,
             duplication_rate=self.virus_duplication_rate,
             mutation_rate=self.virus_mutation_rate,
-            dna=dna,
+            dna=[copy.deepcopy(dna) for _ in range(self.initial_viruses)],
         )
 
         self.datacollector.collect(self)


### PR DESCRIPTION
Found this while checking why mesa/mesa#3853's "examples" CI check was failing. It's unrelated to that PR, reproduces the same way on plain mesa main with no changes there.

`dna = [self.random.randint(0, 9) for _ in range(3)]` is one shared starting DNA meant to seed all `initial_viruses` virus agents, passed straight through as `dna=dna` to `create_agents`. `create_agents` now validates that a sequence kwarg's length matches the agent count (#3824 on mesa/mesa), so a 3-item list against 20 agents raises `ValueError: sequence of length 3 does not match the number of agents (20)` and the model never even starts.

Just broadcasting `[dna] * initial_viruses` would fix the crash but leave every agent holding a reference to the exact same list object. `VirusAgent.generate_dna` mutates that list in place on reproduction (`dna[idx] = (dna[idx] + 1) % 10`), so the first virus that reproduces would silently corrupt every other virus's starting DNA too. `agents.py` already deepcopies `dna` elsewhere for this same reason (`AntibodyAgent`'s memory of a virus's dna), so this gives each of the 20 initial virus agents its own `copy.deepcopy` of the shared starting DNA instead.

Verified against the pre-fix commit: fails with the ValueError above before, passes after. Full `test_examples.py` 25 passed. ruff check + format clean.
